### PR TITLE
Replace separate workspace with .sdlc-loop/ subdirectory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,53 +9,51 @@ This is a multi-agent development loop that orchestrates Claude CLI instances to
 ## Commands
 
 ```bash
-# Run the full pipeline
-uv run supervisor.py "write a function to check if a number is prime"
+# Run the full pipeline (from within the target repo)
+ftl-sdlc-loop "write a function to check if a number is prime"
 
-# Named workspaces - work on existing codebases
-uv run supervisor.py --workspace iris --init-from /path/to/iris  # Clone local repo
-uv run supervisor.py --workspace iris --init-from git@github.com:user/repo.git  # Or clone URL
-uv run supervisor.py --workspace iris "add a new feature"         # Work on it
-uv run supervisor.py --workspace iris --push                      # Push changes back (archives artifacts to logs/)
-uv run supervisor.py --workspace iris --pr                        # Or create a PR
+# Point to a specific repo
+ftl-sdlc-loop --repo /path/to/myproject "add a new feature"
 
-# Feature branches - work on a branch other than main
-uv run supervisor.py --workspace feature-x --init-from /path/to/repo --branch feature-x "implement feature"
-uv run supervisor.py --workspace feature-x --branch feature-x --push  # Push to feature branch
+# Feature branches
+ftl-sdlc-loop --repo /path/to/repo --branch feature-x "implement feature"
+ftl-sdlc-loop --branch feature-x --push  # Push feature branch
+
+# Effort levels
+ftl-sdlc-loop --effort minimal "quick fix"     # ~5-15 min, skip review/user
+ftl-sdlc-loop --effort moderate "add feature"  # ~30-60 min, balanced
+ftl-sdlc-loop --effort maximum "production"    # ~2-3 hours, full pipeline
 
 # Environment variables - load secrets for agents
-uv run supervisor.py --workspace myproject --env ~/.secrets/myproject.env "build API integration"
+ftl-sdlc-loop --env ~/.secrets/myproject.env "build API integration"
 
 # Read task from file (for complex prompts)
-uv run supervisor.py --workspace myproject --prompt-file task.md
+ftl-sdlc-loop --prompt-file task.md
 
 # Plan review workflow - generate plan, review, then implement
-uv run supervisor.py --workspace myproject --plan-only "build feature X"  # Generate plan only
-uv run supervisor.py --workspace myproject --plan workspaces/myproject/PLAN.md "build feature X"  # Use existing plan
+ftl-sdlc-loop --plan-only "build feature X"              # Generate plan only
+ftl-sdlc-loop --plan .sdlc-loop/artifacts/PLAN.md "build feature X"  # Use existing plan
+
+# Push changes
+ftl-sdlc-loop --push              # Push to remote
+ftl-sdlc-loop --pr                # Create a PR
 
 # GitLab workflow - fetch issue, run pipeline, create MR
-# Direct clone from GitLab:
-uv run supervisor.py --workspace issue-285 --init-from git@gitlab.com:org/repo.git --gitlab-issue 285 --effort minimal
-# Or from local bare repo with explicit GitLab remote:
-uv run supervisor.py --workspace issue-285 --init-from ~/git/repo.git --gitlab-remote git@gitlab.com:org/repo.git --gitlab-issue 285 --effort minimal
-# Create MR after completion:
-uv run supervisor.py --workspace issue-285 --gitlab-mr --push
+ftl-sdlc-loop --gitlab-issue 285 --effort minimal
+ftl-sdlc-loop --gitlab-mr --push
 
-# GitHub workflow with code review - fix issue, create PR, review, post comment
-uv run ftl-sdlc-loop --workspace issue-29 --init-from ~/git/ftl2 --github-issue 29 --github-repo benthomasson/ftl2 --github-pr --code-review --effort moderate --no-questions --clean
+# GitHub workflow - fix issue, create PR, review
+ftl-sdlc-loop --github-issue 29 --github-repo benthomasson/ftl2 --github-pr --code-review --effort moderate --no-questions
 
 # With shared understanding from Phase 0
-uv run supervisor.py --understanding workspace/SHARED_UNDERSTANDING.md "build the feature"
+ftl-sdlc-loop --understanding .sdlc-loop/artifacts/SHARED_UNDERSTANDING.md "build the feature"
 
 # Continue previous agent conversations (for follow-up runs)
-uv run supervisor.py --continue "fix the bug from last run"
+ftl-sdlc-loop --continue "fix the bug from last run"
 
 # Continuous mode - process tasks from a queue file
-uv run supervisor.py --continuous                    # uses queue.txt
-uv run supervisor.py --continuous --queue tasks.txt  # custom queue file
-
-# Build shared understanding interactively (Phase 0)
-uv run understand.py "build a REST API for user management"
+ftl-sdlc-loop --continuous                    # uses queue.txt
+ftl-sdlc-loop --continuous --queue tasks.txt  # custom queue file
 
 # Run individual agents
 uv run agent.py planner "design a REST API"
@@ -71,11 +69,19 @@ uv run agent.py --permissions   # show agent tool permissions
 
 ## Architecture
 
-### Three Main Scripts
+### Three Main Modules
 
 - **understand.py** - Phase 0: Interactive shared understanding builder. Creates `SHARED_UNDERSTANDING.md`.
 - **supervisor.py** - Pipeline orchestrator. Runs planner→implementer→reviewer→tester→user loop until satisfied.
-- **agent.py** - Low-level agent runner. Handles session isolation, git branches, permissions, and PID tracking.
+- **agent.py** - Low-level agent runner. Handles session isolation, permissions, and PID tracking.
+
+### Working in the Code Repo
+
+Agents work **directly in the target code repository**. All SDLC state (plans, reviews, session dirs, beliefs) lives under `.sdlc-loop/` which is gitignored. This means:
+
+- No separate workspace clone — agents see the real repo
+- SDLC artifacts never enter the code repo's git history
+- Only actual code changes (from implementer/tester) are committed
 
 ### Agent Pipeline Flow
 
@@ -97,18 +103,15 @@ Planner (WHAT/WHY) → Implementer ←──┬───────────
 - Tester → Implementer: If tests fail, fix before user tries it
 
 Each agent:
-1. Checks out their git branch, merges from main
-2. Gets context from workspace files + previous agents' output
-3. Runs with specific tool permissions (`--allowedTools`)
-4. Commits to their branch, merges back to main
+1. Gets context from `.sdlc-loop/artifacts/` (previous agents' output)
+2. Runs with specific tool permissions (`--allowedTools`)
+3. Source-modifying agents (implementer, tester) commit code directly
 
 ### Key Design Patterns
 
-**Session Isolation**: Each agent runs in `agents/{workspace}/{role}/` directory. Claude CLI stores conversation history per directory, giving each agent persistent memory across iterations.
+**Session Isolation**: Each agent runs in `.sdlc-loop/agents/{role}/` directory. Claude CLI stores conversation history per directory, giving each agent persistent memory across iterations.
 
-**Workspace Separation**: Each agent writes to `workspaces/{workspace}/{role}/`. All can read all directories, but only write to their own.
-
-**Git Coordination**: Every stage commits. Agent branches prevent conflicts. Supervisor merges to main after each stage.
+**Artifact Separation**: SDLC artifacts go to `.sdlc-loop/artifacts/{role}/`. Gitignored — never enters commit history. Only source code changes are committed.
 
 **Conversation Continuation**: Iteration 2+ uses `-c` flag so agents remember previous work. `--continue` flag forces this from iteration 1.
 
@@ -153,18 +156,16 @@ Agents can request human input with markers like `QUESTION FOR HUMAN:`. Supervis
 
 ### Iteration Entries and Versioned Artifacts
 
-Each agent's output is saved with versioned filenames to preserve the full history for evaluation:
+Each agent's output is saved with versioned filenames to preserve the full history:
 
-**Entries** (raw outputs): `entries/iteration-{N}/{role}.md` or `entries/iteration-{N}/{role}_{inner}.md` for inner loops.
+**Entries** (raw outputs): `.sdlc-loop/entries/iteration-{N}/{role}.md`
 
-**Artifacts** (formatted working files):
+**Artifacts** (formatted working files under `.sdlc-loop/artifacts/`):
 - `PLAN_{iteration}.md` - Planner output per iteration
 - `IMPLEMENTATION_{iteration}_{attempt}.md` - Implementer output per attempt
 - `REVIEW_{iteration}_{attempt}.md` - Reviewer output per attempt
 - `TESTER_{iteration}_{attempt}.md` - Tester output per attempt
 - `USER_FEEDBACK_{iteration}.md` - User feedback per iteration
-
-Inner loop attempts are numbered sequentially (e.g., `IMPLEMENTATION_1_1.md`, `IMPLEMENTATION_1_2.md` for review fixes, `IMPLEMENTATION_1_4.md` for test fixes).
 
 ### Beliefs Integration
 
@@ -176,15 +177,21 @@ The supervisor uses [beliefs](https://github.com/benthomasson/beliefs) as a libr
 
 Before the user stage, `beliefs compact` is injected into context. The exit gate also checks: if the user is SATISFIED but active WARNINGs exist, it escalates to a human.
 
-## Runtime Directories (gitignored)
+## SDLC State Directory (.sdlc-loop/)
 
-- `workspaces/{name}/` - Named workspaces, each a git repo with artifacts and agent subdirectories
-  - `entries/iteration-{N}/` - Full agent outputs per iteration (planner.md, implementer.md, etc.)
-  - `beliefs.md` / `nogoods.md` - Beliefs system state
-  - `.env` - Environment variables (copied via `--env`, added to .gitignore)
-- `agents/{name}/` - Session directories per workspace for conversation isolation
-- `pids/` - PID files for running agent processes
-- `logs/` - Archived artifacts from `--push` (e.g., `iris_20260224_143052_artifacts.tar.gz`)
-- `multiagent.log` - Verbose logging output
+All SDLC state lives under `.sdlc-loop/` in the target repo (gitignored):
 
-Default workspace name is `default` if `--workspace` not specified.
+```
+.sdlc-loop/
+├── agents/{role}/          # Claude session dirs (conversation isolation)
+├── artifacts/              # SDLC documents (plans, reviews, etc.)
+│   ├── TASK.md
+│   ├── PLAN_1.md
+│   └── {role}/             # Per-agent artifact subdirs
+├── entries/iteration-{N}/  # Full agent outputs per iteration
+├── beliefs.md              # Beliefs system state
+├── nogoods.md              # Contradictions
+├── logs/                   # Archived artifacts
+├── pids/                   # PID files for running agents
+└── multiagent.log          # Verbose logging
+```

--- a/docs/workspace-architecture.md
+++ b/docs/workspace-architecture.md
@@ -2,63 +2,70 @@
 
 ## Overview
 
-Each agent in the multi-agent loop operates in isolation with:
-- **Separate directories** for file operations
-- **Specific permissions** limiting what tools they can use
-- **Git branches** for version control without conflicts
+Agents work **directly in the target code repository**. All SDLC state — plans, reviews, session history, beliefs — lives under a `.sdlc-loop/` directory that is gitignored. Only actual code changes are committed to the repo.
 
-This design prevents agents from interfering with each other and creates a clear audit trail.
+This design:
+- Eliminates agent confusion about which repo they're in
+- Keeps SDLC artifacts out of the code repo's git history
+- Simplifies the git workflow (no per-agent branches or merge conflicts)
 
 ## Directory Structure
 
 ```
-ftl-sdlc-loop/
-├── agents/                    # Session directories (conversation isolation)
-│   ├── planner/
-│   ├── implementer/
-│   ├── reviewer/
-│   ├── tester/
-│   └── user/
+your-project/                       # The target code repository
+├── .sdlc-loop/                     # Gitignored — all SDLC state
+│   ├── agents/                     # Session directories (conversation isolation)
+│   │   ├── understand/
+│   │   ├── planner/
+│   │   ├── implementer/
+│   │   ├── reviewer/
+│   │   ├── tester/
+│   │   └── user/
+│   │
+│   ├── artifacts/                  # SDLC documents
+│   │   ├── TASK.md                 # Task description
+│   │   ├── SHARED_UNDERSTANDING.md
+│   │   ├── CUMULATIVE_UNDERSTANDING.md
+│   │   ├── PLAN_1.md              # Versioned artifacts
+│   │   ├── IMPLEMENTATION_1_1.md
+│   │   ├── REVIEW_1_1.md
+│   │   ├── planner/               # Per-agent output dirs
+│   │   ├── implementer/
+│   │   ├── reviewer/
+│   │   ├── tester/
+│   │   └── user/
+│   │
+│   ├── entries/                    # Iteration journals
+│   │   └── iteration-1/
+│   │       ├── planner.md
+│   │       ├── implementer_1.md
+│   │       ├── reviewer_1.md
+│   │       └── tester_1.md
+│   │
+│   ├── beliefs.md                  # Beliefs system state
+│   ├── nogoods.md                  # Contradictions
+│   ├── logs/                       # Archives
+│   ├── pids/                       # PID files for running agents
+│   └── multiagent.log              # Debug logging
 │
-├── workspace/                 # Shared git repo with agent subdirectories
-│   ├── .git/
-│   ├── TASK.md               # Shared: task description
-│   ├── SHARED_UNDERSTANDING.md
-│   ├── CUMULATIVE_UNDERSTANDING.md
-│   │
-│   ├── planner/              # Planner's workspace
-│   │   └── PLAN.md
-│   │
-│   ├── implementer/          # Implementer's workspace
-│   │   ├── is_prime.py
-│   │   └── IMPLEMENTATION.md
-│   │
-│   ├── reviewer/             # Reviewer's workspace
-│   │   └── REVIEW.md
-│   │
-│   ├── tester/               # Tester's workspace
-│   │   ├── test_is_prime.py
-│   │   └── USAGE.md
-│   │
-│   └── user/                 # User's workspace
-│       └── FEEDBACK.md
-│
-└── multiagent.log            # Log file for debugging
+├── .gitignore                      # Contains .sdlc-loop/
+├── src/                            # Your actual source code
+└── tests/                          # Your actual tests
 ```
 
 ### Two Types of Directories
 
-**Session Directories (`agents/{role}/`)**
+**Session Directories (`.sdlc-loop/agents/{role}/`)**
 - Used for Claude CLI conversation isolation
 - Claude stores session history per directory
 - Each agent has persistent memory within their session
 - Agents can continue conversations with `-c` flag
 
-**Workspace Directories (`workspace/{role}/`)**
-- Used for file operations (read, write, edit)
-- Each agent writes only to their subdirectory
-- All agents can read from all directories
-- Version controlled with git
+**Artifact Directories (`.sdlc-loop/artifacts/{role}/`)**
+- Used for SDLC document output (plans, reviews, reports)
+- Each agent writes to their own subdirectory
+- All agents can read from all artifact directories
+- Gitignored — never enters commit history
 
 ## Agent Permissions
 
@@ -66,12 +73,12 @@ Each agent has specific tools enabled:
 
 | Agent | Read | Write | Edit | Bash | Purpose |
 |-------|------|-------|------|------|---------|
-| **understand** | ✓ | - | - | - | Gather context, no modifications |
-| **planner** | ✓ | ✓ | - | - | Read codebase, write plan |
-| **implementer** | ✓ | ✓ | ✓ | - | Full file operations for coding |
-| **reviewer** | ✓ | ✓ | - | - | Read code, write review |
-| **tester** | ✓ | ✓ | ✓ | ✓ | Create tests, run them |
-| **user** | ✓ | ✓ | - | ✓ | Read code, run it, write feedback |
+| **understand** | yes | - | - | - | Gather context, no modifications |
+| **planner** | yes | yes | - | - | Read codebase, write plan |
+| **implementer** | yes | yes | yes | - | Full file operations for coding |
+| **reviewer** | yes | yes | - | - | Read code, write review |
+| **tester** | yes | yes | yes | yes | Create tests, run them |
+| **user** | yes | yes | - | yes | Read code, run it, write feedback |
 
 ### Permission Rationale
 
@@ -81,85 +88,29 @@ Each agent has specific tools enabled:
 - **Tester** needs Bash to run tests
 - **User** needs Bash to actually use the software
 
-### Viewing Permissions
-
-```bash
-uv run agent.py --permissions
-```
-
 ## Git Workflow
 
-### Branches
+### Direct Commits
 
-Each agent works on their own branch:
-
-```
-main                    ← Shared state
-├── planner            ← Planner's commits
-├── implementer        ← Implementer's commits
-├── reviewer           ← Reviewer's commits
-├── tester             ← Tester's commits
-└── user               ← User's commits
-```
-
-### Workflow Per Agent
-
-1. **Checkout**: Agent checks out their branch (creates if new)
-2. **Merge**: Pull latest changes from `main`
-3. **Work**: Agent does their work with permitted tools
-4. **Commit**: Changes committed to agent's branch
-5. **Merge back**: Supervisor merges agent's branch to `main`
+Source-modifying agents (implementer, tester) commit directly to the current branch:
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                    main branch                       │
-└─────────────────────────────────────────────────────┘
-        │           ↑           ↑           ↑
-        ↓           │           │           │
-    ┌───────┐   ┌───────┐   ┌───────┐   ┌───────┐
-    │planner│   │implmtr│   │reviewr│   │tester │
-    │branch │   │branch │   │branch │   │branch │
-    └───────┘   └───────┘   └───────┘   └───────┘
-        │           │           │           │
-        ↓           ↓           ↓           ↓
-    [commits]   [commits]   [commits]   [commits]
+feature-branch
+  ├── [implementer] Implement binary search
+  ├── [implementer] Fix review feedback
+  ├── [tester] Add test files
+  └── (squashed before push)
 ```
 
-### Why Branches?
+Non-source agents (planner, reviewer, user) produce no commits — their outputs are SDLC artifacts stored in `.sdlc-loop/artifacts/` which is gitignored.
 
-1. **No conflicts**: Each agent writes to their own directory on their own branch
-2. **Audit trail**: Git history shows exactly what each agent did
-3. **Rollback**: Can revert individual agent's work without affecting others
-4. **Parallel work**: Future support for running agents in parallel
+### Push Workflow
 
-### Viewing Branches
-
-```bash
-uv run agent.py --branches
-
-# Or directly:
-cd workspace && git branch -v
-```
-
-### Git Log
-
-```bash
-cd workspace && git log --oneline
-```
-
-Example output:
-```
-a1b2c3d [user] Work from user
-e4f5g6h [tester] Work from tester
-i7j8k9l [reviewer] Work from reviewer
-m0n1o2p [implementer] Work from implementer
-q3r4s5t [planner] Work from planner
-u6v7w8x [supervisor] Start task: write a function...
-```
+When pushing (`--push` or `--pr`), commits are optionally squashed into a single commit for a clean history.
 
 ## Context Flow
 
-Each agent receives context from previous stages:
+Each agent receives context from previous agents' artifact directories:
 
 ```
 Planner receives:
@@ -167,69 +118,42 @@ Planner receives:
 
 Implementer receives:
   ├── TASK.md, SHARED_UNDERSTANDING.md
-  └── planner/PLAN.md
+  └── artifacts/planner/PLAN.md
 
 Reviewer receives:
   ├── TASK.md, SHARED_UNDERSTANDING.md
-  ├── planner/PLAN.md
-  └── implementer/*.py, implementer/IMPLEMENTATION.md
+  ├── artifacts/planner/PLAN.md
+  └── artifacts/implementer/*.py, artifacts/implementer/IMPLEMENTATION.md
 
 Tester receives:
   ├── All of the above
-  └── reviewer/REVIEW.md
+  └── artifacts/reviewer/REVIEW.md
 
 User receives:
   ├── All of the above
-  └── tester/USAGE.md, tester/test_*.py
+  └── artifacts/tester/USAGE.md, artifacts/tester/test_*.py
 ```
 
-This is automatic - the agent runner gathers context from previous agents' directories and includes it in the prompt.
+This is automatic — the agent runner gathers context from previous agents' artifact directories and includes it in the prompt.
 
 ## Isolation Benefits
 
 ### Prevents Interference
-- Implementer can't accidentally delete planner's work
-- Reviewer can't modify the implementation
-- Each agent has clear boundaries
+- SDLC artifacts can't accidentally enter git history
+- Agents write to their own artifact directories
+- Only code changes are committed
 
 ### Clear Ownership
-- Every file has a clear owner (the agent whose directory it's in)
-- Easy to see who created what
-- Blame/attribution is straightforward
+- Every artifact has a clear owner (the agent whose directory it's in)
+- Code changes are attributed to the agent that made them
+- SDLC state is separate from code state
 
 ### Debugging
-- If something goes wrong, check that agent's directory
-- Git log shows exactly what changed
-- Can diff between iterations
+- Check `.sdlc-loop/artifacts/{role}/` for an agent's output
+- Git log shows only meaningful code changes
+- `.sdlc-loop/multiagent.log` has verbose debug output
 
-### Recovery
-- Roll back one agent's work: `git revert <commit>`
-- Reset an agent: delete their branch and directory
-- Start fresh: `rm -rf workspace && uv run supervisor.py ...`
-
-## Future: True Forks
-
-The current implementation uses branches on a single repo. A future enhancement could use actual GitHub forks:
-
-```
-shared-repo (GitHub)
-    ↑
-    ├── planner-fork
-    ├── implementer-fork
-    ├── reviewer-fork
-    ├── tester-fork
-    └── user-fork
-```
-
-Each agent would:
-1. Clone their fork
-2. Work locally
-3. Push to their fork
-4. Create PR to shared repo
-5. Supervisor merges PRs
-
-This would enable:
-- True isolation (separate repos)
-- Parallel agents on different machines
-- PR-based review before merging
-- GitHub Actions for CI on each PR
+### Simplicity
+- No workspace clones to manage
+- No per-agent branches or merge conflicts
+- Agents work in the real repo — no confusion about context

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -48,14 +48,6 @@ def get_artifacts_dir() -> Path:
     return get_sdlc_dir() / "artifacts"
 
 
-def get_workspace_dir(workspace_name: str | None = None) -> Path:
-    """Get the workspace directory (the code repo root).
-
-    The workspace_name parameter is accepted for backward compatibility
-    but ignored — agents always work in the repo root.
-    """
-    return get_repo_root()
-
 
 def get_agents_dir(workspace_name: str | None = None) -> Path:
     """Get the agents session directory under .sdlc-loop/."""
@@ -288,12 +280,6 @@ def get_workspace_context(role: str) -> str:
             for f in sorted(agent_dir.glob("*.md"))[:3]:
                 content = f.read_text()[:2000]
                 context_parts.append(f"## {agent}/{f.name}\n\n{content}")
-            if agent == "implementer":
-                for f in sorted(agent_dir.glob("*.py"))[:3]:
-                    content = f.read_text()[:3000]
-                    context_parts.append(
-                        f"## {agent}/{f.name}\n\n```python\n{content}\n```"
-                    )
 
     return "\n\n---\n\n".join(context_parts) if context_parts else ""
 

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -62,22 +62,6 @@ def get_agents_dir(workspace_name: str | None = None) -> Path:
     return get_sdlc_dir() / "agents"
 
 
-# Workspace name — kept for backward compat with supervisor references
-DEFAULT_WORKSPACE = "default"
-_current_workspace = DEFAULT_WORKSPACE
-
-
-def set_workspace(name: str) -> None:
-    """Set the current workspace name (legacy, mostly unused)."""
-    global _current_workspace
-    _current_workspace = name
-
-
-def get_workspace_name() -> str:
-    """Get the current workspace name."""
-    return _current_workspace
-
-
 # Target branch for commits (default: main)
 _target_branch = "main"
 

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -288,7 +288,7 @@ def get_workspace_context(role: str) -> str:
     artifacts = get_artifacts_dir()
     context_parts = []
 
-    shared_files = ["TASK.md", "SHARED_UNDERSTANDING.md", "CUMULATIVE_UNDERSTANDING.md"]
+    shared_files = ["TASK.md", "PLAN.md", "SHARED_UNDERSTANDING.md", "CUMULATIVE_UNDERSTANDING.md"]
     for filename in shared_files:
         filepath = artifacts / filename
         if filepath.exists():

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -49,7 +49,7 @@ def get_artifacts_dir() -> Path:
 
 
 
-def get_agents_dir(workspace_name: str | None = None) -> Path:
+def get_agents_dir() -> Path:
     """Get the agents session directory under .sdlc-loop/."""
     return get_sdlc_dir() / "agents"
 
@@ -270,6 +270,12 @@ def get_workspace_context(role: str) -> str:
         if filepath.exists():
             content = filepath.read_text()[:3000]
             context_parts.append(f"## {filename}\n\n{content}")
+
+    for f in sorted(artifacts.glob("*.md"))[:10]:
+        if f.name in shared_files:
+            continue
+        content = f.read_text()[:2000]
+        context_parts.append(f"## {f.name}\n\n{content}")
 
     agent_order = ["planner", "implementer", "reviewer", "tester", "user"]
     for agent in agent_order:

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -9,17 +9,12 @@ Agent runner utility - runs claude -p in a specific agent directory
 to maintain separate conversation contexts per agent role.
 
 Each agent has:
-- Their own session directory (agents/{role}/) for conversation isolation
-- Their own workspace subdirectory (workspace/{role}/) for file operations
-- Their own git branch for commits
+- Their own session directory (.sdlc-loop/agents/{role}/) for conversation isolation
+- Their own artifact directory (.sdlc-loop/artifacts/{role}/) for SDLC outputs
 - Specific tool permissions
 
-Workflow:
-1. Agent checks out their branch, merges from main
-2. Agent reads files from workspace + gets prompt
-3. Agent does work (with tools if permitted)
-4. Agent commits to their branch
-5. Supervisor merges back to main when stage completes
+Source-modifying agents (implementer, tester) work directly in the code repo root.
+All SDLC artifacts are stored under .sdlc-loop/ which is gitignored.
 """
 
 import os
@@ -28,19 +23,52 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-BASE_DIR = Path.cwd()
-LOG_FILE = BASE_DIR / "multiagent.log"
-PIDS_DIR = BASE_DIR / "pids"
+# Repo root — the actual code repository agents work in
+_repo_root: Path | None = None
 
-# Default workspace name for backward compatibility
+
+def set_repo_root(path: Path) -> None:
+    """Set the target code repo root."""
+    global _repo_root
+    _repo_root = path
+
+
+def get_repo_root() -> Path:
+    """Get the target code repo root. Defaults to CWD."""
+    return _repo_root or Path.cwd()
+
+
+def get_sdlc_dir() -> Path:
+    """Get the .sdlc-loop directory for SDLC state."""
+    return get_repo_root() / ".sdlc-loop"
+
+
+def get_artifacts_dir() -> Path:
+    """Get the artifacts directory for SDLC documents."""
+    return get_sdlc_dir() / "artifacts"
+
+
+def get_workspace_dir(workspace_name: str | None = None) -> Path:
+    """Get the workspace directory (the code repo root).
+
+    The workspace_name parameter is accepted for backward compatibility
+    but ignored — agents always work in the repo root.
+    """
+    return get_repo_root()
+
+
+def get_agents_dir(workspace_name: str | None = None) -> Path:
+    """Get the agents session directory under .sdlc-loop/."""
+    return get_sdlc_dir() / "agents"
+
+
+# Workspace name — kept for backward compat with supervisor references
 DEFAULT_WORKSPACE = "default"
-
-# Current workspace name (can be set via set_workspace())
 _current_workspace = DEFAULT_WORKSPACE
 
 
 def set_workspace(name: str) -> None:
-    """Set the current workspace name."""
+    """Set the current workspace name (legacy, mostly unused)."""
     global _current_workspace
     _current_workspace = name
 
@@ -50,30 +78,18 @@ def get_workspace_name() -> str:
     return _current_workspace
 
 
-def get_workspace_dir(workspace_name: str | None = None) -> Path:
-    """Get the workspace directory for a given workspace name."""
-    name = workspace_name or _current_workspace
-    return BASE_DIR / "workspaces" / name
-
-
-def get_agents_dir(workspace_name: str | None = None) -> Path:
-    """Get the agents directory for a given workspace name."""
-    name = workspace_name or _current_workspace
-    return BASE_DIR / "agents" / name
-
-
-# Target branch for agent merges (default: main)
+# Target branch for commits (default: main)
 _target_branch = "main"
 
 
 def set_target_branch(branch: str) -> None:
-    """Set the target branch for agent merges."""
+    """Set the target branch for work."""
     global _target_branch
     _target_branch = branch
 
 
 def get_target_branch() -> str:
-    """Get the target branch for agent merges."""
+    """Get the target branch."""
     return _target_branch
 
 
@@ -86,7 +102,9 @@ def _get_log_file():
     """Get or create log file handle."""
     global _log_file_handle
     if _log_file_handle is None:
-        _log_file_handle = open(LOG_FILE, "a")
+        log_file = get_sdlc_dir() / "multiagent.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        _log_file_handle = open(log_file, "a")
     return _log_file_handle
 
 
@@ -95,21 +113,24 @@ def log(msg: str, level: str = "INFO"):
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     log_line = f"[{timestamp}] [{level}] {msg}"
 
-    # Always write to file
     f = _get_log_file()
     f.write(log_line + "\n")
     f.flush()
 
-    # Print to stderr if verbose or error/warn
     if VERBOSE or level in ["ERROR", "WARN"]:
         print(log_line, file=sys.stderr)
 
 
 # PID file management
+def _pids_dir() -> Path:
+    return get_sdlc_dir() / "pids"
+
+
 def write_pid(role: str, pid: int) -> Path:
     """Write PID file for an agent."""
-    PIDS_DIR.mkdir(parents=True, exist_ok=True)
-    pid_file = PIDS_DIR / f"{role}.pid"
+    pids = _pids_dir()
+    pids.mkdir(parents=True, exist_ok=True)
+    pid_file = pids / f"{role}.pid"
     pid_file.write_text(str(pid))
     log(f"Wrote PID {pid} to {pid_file}")
     return pid_file
@@ -117,23 +138,21 @@ def write_pid(role: str, pid: int) -> Path:
 
 def read_pid(role: str) -> int | None:
     """Read PID for an agent, returns None if not running."""
-    pid_file = PIDS_DIR / f"{role}.pid"
+    pid_file = _pids_dir() / f"{role}.pid"
     if not pid_file.exists():
         return None
     try:
         pid = int(pid_file.read_text().strip())
-        # Check if process is still running
-        os.kill(pid, 0)  # Signal 0 just checks if process exists
+        os.kill(pid, 0)
         return pid
     except (ValueError, ProcessLookupError, PermissionError):
-        # Invalid PID or process not running
         pid_file.unlink(missing_ok=True)
         return None
 
 
 def clear_pid(role: str) -> None:
     """Remove PID file for an agent."""
-    pid_file = PIDS_DIR / f"{role}.pid"
+    pid_file = _pids_dir() / f"{role}.pid"
     if pid_file.exists():
         pid_file.unlink()
         log(f"Cleared PID file for {role}")
@@ -194,7 +213,7 @@ AGENT_PERMISSIONS = {
     "implementer": {
         "allowed_tools": ["Read", "Write", "Edit", "Glob", "Grep"],
         "can_write": True,
-        "description": "Can read/write/edit files in their workspace",
+        "description": "Can read/write/edit files in the project",
     },
     "reviewer": {
         "allowed_tools": ["Read", "Glob", "Grep", "Write"],
@@ -232,139 +251,59 @@ def log_separator(title: str = "NEW RUN"):
     f.flush()
 
 
-def init_workspace():
-    """Initialize the workspace as a git repo if needed."""
-    workspace = get_workspace_dir()
-    workspace.mkdir(parents=True, exist_ok=True)
-    git_dir = workspace / ".git"
-    if not git_dir.exists():
-        log(f"Initializing workspace git repo at {workspace}")
-        git_cmd(["init"], workspace)
-        (workspace / ".gitkeep").touch()
-        git_cmd(["add", ".gitkeep"], workspace)
-        git_cmd(["commit", "-m", "Initialize workspace"], workspace)
-        log("Workspace initialized")
-
-
-def setup_agent_branch(role: str) -> Path:
+def setup_agent_workspace(role: str) -> Path:
     """
-    Set up agent's workspace subdirectory and git branch.
-    Returns the agent's workspace directory.
+    Create agent's artifact directory under .sdlc-loop/.
+    Returns the agent's artifact directory.
     """
-    init_workspace()
-    workspace = get_workspace_dir()
-
-    # Create agent's subdirectory
-    agent_workspace = workspace / role
-    agent_workspace.mkdir(parents=True, exist_ok=True)
-    log(f"Agent workspace: {agent_workspace}")
-
-    # Check if branch exists
-    result = git_cmd(["branch", "--list", role], workspace)
-    branch_exists = role in result.stdout
-
-    if not branch_exists:
-        log(f"Creating new branch: {role}")
-        git_cmd(["checkout", "-b", role], workspace)
-    else:
-        log(f"Checking out existing branch: {role}")
-        git_cmd(["checkout", role], workspace)
-
-    # Merge latest from target branch
-    log(f"Merging latest from {_target_branch} into {role}")
-    result = git_cmd(["merge", _target_branch, "--no-edit"], workspace)
-    if result.returncode != 0:
-        log(f"Merge warning: {result.stderr}", "WARN")
-
-    return agent_workspace
+    artifact_dir = get_artifacts_dir() / role
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    log(f"Agent artifact dir: {artifact_dir}")
+    return artifact_dir
 
 
 def commit_agent_work(role: str, message: str) -> bool:
-    """Commit any changes the agent made."""
-    workspace = get_workspace_dir()
-    log(f"Checking for changes in {role}/")
-
-    # Stage changes in agent's directory
-    git_cmd(["add", role + "/"], workspace)
-
-    # Source-modifying agents (implementer, tester) run in the workspace root
-    # and edit files outside their subdirectory. Stage all changes so source
-    # edits are captured in the agent's commit, but exclude other agents'
-    # subdirectories to avoid pulling in their uncommitted work.
+    """Commit any code changes the agent made (artifacts are gitignored)."""
     source_modifying_roles = {"implementer", "tester"}
-    if role in source_modifying_roles:
-        log(f"Staging source changes for {role}")
-        other_agent_dirs = [r for r in AGENT_PERMISSIONS if r != role]
-        pathspec = ["--", "."] + [f":!{d}/" for d in other_agent_dirs]
-        git_cmd(["add"] + pathspec, workspace)
+    if role not in source_modifying_roles:
+        return False
 
-    # Check if there are changes to commit
-    result = git_cmd(["diff", "--cached", "--quiet"], workspace)
+    repo = get_repo_root()
+    log(f"Staging source changes for {role}")
+
+    git_cmd(["add", "--", ".", ":!.sdlc-loop/"], repo)
+
+    result = git_cmd(["diff", "--cached", "--quiet"], repo)
     if result.returncode == 0:
         log(f"No changes to commit for {role}")
-        return False  # No changes
+        return False
 
-    # Commit
     log(f"Committing changes for {role}: {message}")
-    git_cmd(["commit", "-m", f"[{role}] {message}"], workspace)
+    git_cmd(["commit", "-m", f"[{role}] {message}"], repo)
     return True
 
 
-def merge_to_main(role: str) -> bool:
-    """Merge agent's branch back to the target branch."""
-    workspace = get_workspace_dir()
-    log(f"Merging {role} branch back to {_target_branch}")
-
-    # Switch to target branch
-    git_cmd(["checkout", _target_branch], workspace)
-
-    # Merge agent's branch
-    result = git_cmd(["merge", role, "--no-edit"], workspace)
-    if result.returncode == 0:
-        log(f"Successfully merged {role} to {_target_branch}")
-        return True
-
-    # Merge failed — abort and retry with theirs strategy for source-modifying agents
-    log(f"Merge failed: {result.stderr}", "ERROR")
-    git_cmd(["merge", "--abort"], workspace)
-
-    source_modifying_roles = {"implementer", "tester"}
-    if role in source_modifying_roles:
-        log(f"Retrying merge with -X theirs for {role} (source changes take priority)")
-        result = git_cmd(["merge", role, "--no-edit", "-X", "theirs"], workspace)
-        if result.returncode == 0:
-            log(f"Successfully merged {role} to {_target_branch} with -X theirs")
-            return True
-        log(f"Merge with -X theirs also failed: {result.stderr}", "ERROR")
-        git_cmd(["merge", "--abort"], workspace)
-
-    return False
-
-
 def get_workspace_context(role: str) -> str:
-    """Read relevant files from workspace to provide context to the agent."""
-    workspace = get_workspace_dir()
+    """Read relevant files from .sdlc-loop/artifacts/ to provide context to the agent."""
+    artifacts = get_artifacts_dir()
     context_parts = []
 
-    # Read shared files from main workspace
     shared_files = ["TASK.md", "SHARED_UNDERSTANDING.md", "CUMULATIVE_UNDERSTANDING.md"]
     for filename in shared_files:
-        filepath = workspace / filename
+        filepath = artifacts / filename
         if filepath.exists():
-            content = filepath.read_text()[:3000]  # Limit size
+            content = filepath.read_text()[:3000]
             context_parts.append(f"## {filename}\n\n{content}")
 
-    # Read files from other agents' directories (for context)
     agent_order = ["planner", "implementer", "reviewer", "tester", "user"]
     for agent in agent_order:
         if agent == role:
-            break  # Only read from previous agents
-        agent_dir = workspace / agent
+            break
+        agent_dir = artifacts / agent
         if agent_dir.exists():
-            for f in sorted(agent_dir.glob("*.md"))[:3]:  # Limit files
+            for f in sorted(agent_dir.glob("*.md"))[:3]:
                 content = f.read_text()[:2000]
                 context_parts.append(f"## {agent}/{f.name}\n\n{content}")
-            # Also read code files from implementer
             if agent == "implementer":
                 for f in sorted(agent_dir.glob("*.py"))[:3]:
                     content = f.read_text()[:3000]
@@ -382,26 +321,23 @@ def run_agent(
     Run a claude prompt as a specific agent role.
 
     Each role has:
-    - Session directory (agents/{workspace}/{role}/) for conversation isolation
-    - Workspace subdirectory (workspaces/{workspace}/{role}/) for file operations
-    - Git branch for version control
+    - Session directory (.sdlc-loop/agents/{role}/) for conversation isolation
+    - Artifact directory (.sdlc-loop/artifacts/{role}/) for SDLC outputs
+    - Source-modifying agents work in the project root directly
     """
-    workspace = get_workspace_dir()
+    repo = get_repo_root()
     agents_dir = get_agents_dir()
 
     log(f"{'='*50}")
     log(f"Starting agent: {role.upper()}")
     log(f"{'='*50}")
 
-    # Set up session directory (for conversation isolation)
     agent_session_dir = agents_dir / role
     agent_session_dir.mkdir(parents=True, exist_ok=True)
     log(f"Session directory: {agent_session_dir}")
 
-    # Set up workspace and git branch
-    agent_workspace = setup_agent_branch(role)
+    agent_artifact_dir = setup_agent_workspace(role)
 
-    # Get permissions
     permissions = AGENT_PERMISSIONS.get(
         role,
         {
@@ -412,7 +348,6 @@ def run_agent(
     )
     log(f"Permissions: {permissions['allowed_tools']}")
 
-    # Get context from workspace
     log(f"Gathering workspace context for {role}")
     workspace_context = get_workspace_context(role)
     if workspace_context:
@@ -420,11 +355,9 @@ def run_agent(
     else:
         log("No prior context found")
 
-    # Determine working directory before building prompt so it can be referenced
     source_modifying_roles = {"implementer", "tester"}
-    agent_cwd = workspace if role in source_modifying_roles else agent_session_dir
+    agent_cwd = repo if role in source_modifying_roles else agent_session_dir
 
-    # Build enhanced prompt with context
     full_prompt = message
     if workspace_context:
         full_prompt = f"""## WORKSPACE CONTEXT
@@ -438,30 +371,24 @@ The following files are available from previous stages:
 ## YOUR TASK
 
 {message}
-
----
-
-Your workspace directory is: {agent_workspace}
-Write any output files to this directory.
-
-IMPORTANT: Your working directory is {agent_cwd}. Only modify files within this directory.
-Do NOT modify files outside this directory (e.g. in the original source repo).
 """
 
-    # Build command
+    full_prompt += f"""
+You are working directly in the project at: {repo}
+Write any SDLC output files (plans, reviews, reports) to: {agent_artifact_dir}
+Your working directory is {agent_cwd}.
+"""
+
     cmd = ["claude", "-p", full_prompt]
 
     if continue_session:
         cmd.append("-c")
 
-    # Add allowed tools
     if "allowed_tools" in permissions:
         cmd.extend(["--allowedTools", ",".join(permissions["allowed_tools"])])
 
-    # Add workspace directory for file access
-    cmd.extend(["--add-dir", str(workspace)])
+    cmd.extend(["--add-dir", str(repo)])
 
-    # Remove CLAUDECODE env var to allow running from within Claude Code
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)
 
@@ -471,7 +398,6 @@ Do NOT modify files outside this directory (e.g. in the original source repo).
     )
     log(f"Working directory: {agent_cwd}")
 
-    # Use Popen to capture PID for monitoring/killing
     process = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
@@ -481,20 +407,17 @@ Do NOT modify files outside this directory (e.g. in the original source repo).
         cwd=agent_cwd,
     )
 
-    # Write PID file so we can kill if needed
     write_pid(role, process.pid)
 
     try:
         stdout, stderr = process.communicate()
         returncode = process.returncode
     finally:
-        # Always clean up PID file when done
         clear_pid(role)
 
     log(f"Claude returned with code {returncode}")
     output = stdout.strip()
 
-    # Update result references for rest of function
     class Result:
         pass
 
@@ -509,11 +432,10 @@ Do NOT modify files outside this directory (e.g. in the original source repo).
             "WARN" if result.returncode == 0 else "ERROR",
         )
 
-    # Auto-commit if agent has write permissions
     if auto_commit and permissions.get("can_write"):
         committed = commit_agent_work(role, f"Work from {role}")
         if committed:
-            output += f"\n\n[Committed changes to {role} branch]"
+            output += f"\n\n[Committed code changes from {role}]"
 
     if result.returncode != 0 and result.stderr:
         log(f"Agent {role} failed", "ERROR")
@@ -522,11 +444,6 @@ Do NOT modify files outside this directory (e.g. in the original source repo).
     log(f"Agent {role} completed successfully")
     log(f"Output length: {len(output)} chars")
     return output
-
-
-def finalize_agent(role: str) -> bool:
-    """Merge agent's work back to main branch."""
-    return merge_to_main(role)
 
 
 def reset_agent(role: str) -> None:
@@ -551,17 +468,8 @@ def show_permissions():
         print(f"\n{role}:")
         print(f"  Tools: {tools}")
         print(f"  Can Write: {can_write}")
-        print(f"  Workspace: workspace/{role}/")
+        print(f"  Artifacts: .sdlc-loop/artifacts/{role}/")
         print(f"  {perms.get('description', '')}")
-
-
-def show_branches():
-    """Show git branches in workspace."""
-    init_workspace()
-    workspace = get_workspace_dir()
-    result = git_cmd(["branch", "-v"], workspace)
-    print(f"Workspace branches ({get_workspace_name()}):")
-    print(result.stdout)
 
 
 if __name__ == "__main__":
@@ -571,7 +479,6 @@ if __name__ == "__main__":
         print(f"Usage: {sys.argv[0]} <role> <message>")
         print(f"       {sys.argv[0]} <role> -c <message>  (continue session)")
         print(f"       {sys.argv[0]} --permissions  (show agent permissions)")
-        print(f"       {sys.argv[0]} --branches     (show workspace branches)")
         print(f"       {sys.argv[0]} --status       (show running agents)")
         print(f"       {sys.argv[0]} --kill <role>  (kill a running agent)")
         print(f"       {sys.argv[0]} --kill-all     (kill all running agents)")
@@ -587,9 +494,9 @@ if __name__ == "__main__":
             print("Error: role required for --kill")
             sys.exit(1)
         role = sys.argv[2]
-        signal_num = 15  # SIGTERM
+        signal_num = 15
         if len(sys.argv) > 3 and sys.argv[3] == "-9":
-            signal_num = 9  # SIGKILL
+            signal_num = 9
         kill_agent(role, signal_num)
         sys.exit(0)
 
@@ -604,10 +511,6 @@ if __name__ == "__main__":
 
     if sys.argv[1] == "--permissions":
         show_permissions()
-        sys.exit(0)
-
-    if sys.argv[1] == "--branches":
-        show_branches()
         sys.exit(0)
 
     role = sys.argv[1]

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -1213,6 +1213,7 @@ QUESTION FOR HUMAN: [your question here]"""
         "implementer",
         implement_prompt,
         continue_session=(continue_conversations or iteration > 1),
+        auto_commit=False,
     )
 
     # Phase 2: Describe what was done (continue session so it has context)
@@ -1223,7 +1224,7 @@ what changes you made in each one. Include a self-review:
 3. What was unclear in the plan?
 4. Any concerns for the reviewer?"""
 
-    response = run_agent("implementer", describe_prompt, continue_session=True)
+    response = run_agent("implementer", describe_prompt, continue_session=True, auto_commit=False)
 
     # Extract and save code blocks
     # Supports multiple formats:
@@ -1434,7 +1435,8 @@ If you need clarification or are blocked, escalate to a human:
 QUESTION FOR HUMAN: [your question here]"""
 
     response = run_agent(
-        "tester", prompt, continue_session=(continue_conversations or iteration > 1)
+        "tester", prompt, continue_session=(continue_conversations or iteration > 1),
+        auto_commit=False,
     )
 
     # Extract and save test files

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -2664,23 +2664,34 @@ def main():
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)
     if gitlab_remote_url:
-        subprocess.run(
-            ["git", "remote", "add", "gitlab", gitlab_remote_url],
-            cwd=repo,
-            env=env,
-            capture_output=True,
+        existing = subprocess.run(
+            ["git", "remote", "get-url", "gitlab"],
+            cwd=repo, env=env, capture_output=True, text=True,
         )
-        print(f"  Added 'gitlab' remote: {gitlab_remote_url}")
-    # If GitHub repo is specified, update origin
+        if existing.returncode != 0:
+            subprocess.run(
+                ["git", "remote", "add", "gitlab", gitlab_remote_url],
+                cwd=repo, env=env, capture_output=True,
+            )
+            print(f"  Added 'gitlab' remote: {gitlab_remote_url}")
+        elif existing.stdout.strip() != gitlab_remote_url:
+            subprocess.run(
+                ["git", "remote", "set-url", "gitlab", gitlab_remote_url],
+                cwd=repo, env=env, capture_output=True,
+            )
+            print(f"  Updated 'gitlab' remote: {gitlab_remote_url}")
     if github_issue_repo:
         github_url = f"git@github.com:{github_issue_repo}.git"
-        subprocess.run(
-            ["git", "remote", "set-url", "origin", github_url],
-            cwd=repo,
-            env=env,
-            capture_output=True,
+        existing = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=repo, env=env, capture_output=True, text=True,
         )
-        print(f"  Set origin to: {github_url}")
+        if existing.returncode != 0 or existing.stdout.strip() != github_url:
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", github_url],
+                cwd=repo, env=env, capture_output=True,
+            )
+            print(f"  Set origin to: {github_url}")
 
     # Handle --env early (load environment variables before running agents)
     if "--env" in args:

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -867,6 +867,14 @@ def save_artifact(name: str, content: str) -> Path:
     return path
 
 
+def save_source_file(name: str, content: str) -> Path:
+    """Save extracted source code to the repo root (not artifacts)."""
+    path = get_repo_root() / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
 def parse_verdict(response: str) -> dict:
     """Parse a structured verdict block from agent output.
 
@@ -1233,7 +1241,7 @@ what changes you made in each one. Include a self-review:
         re.DOTALL,
     )
     for lang, filename, code in pattern1:
-        save_artifact(filename.strip(), code.strip())
+        save_source_file(filename.strip(), code.strip())
         files_created.append(filename.strip())
 
     # Pattern 2: **File: `filename.py`** followed by ```\ncode```
@@ -1244,7 +1252,7 @@ what changes you made in each one. Include a self-review:
     )
     for filename, code in pattern2:
         if filename not in files_created:
-            save_artifact(filename.strip(), code.strip())
+            save_source_file(filename.strip(), code.strip())
             files_created.append(filename.strip())
 
     # Pattern 3: # filename.py as first line in code block
@@ -1255,7 +1263,7 @@ what changes you made in each one. Include a self-review:
     )
     for filename, code in pattern3:
         if filename not in files_created:
-            save_artifact(filename.strip(), code.strip())
+            save_source_file(filename.strip(), code.strip())
             files_created.append(filename.strip())
 
     # files_created is already populated above
@@ -1440,7 +1448,7 @@ QUESTION FOR HUMAN: [your question here]"""
         r"```(?:python)?\s*(test_\S+\.py)\n(.*?)```", response, re.DOTALL
     )
     for filename, code in pattern1:
-        save_artifact(filename.strip(), code.strip())
+        save_source_file(filename.strip(), code.strip())
         test_files.append(filename.strip())
 
     # Pattern 2: **File: `test_*.py`** followed by code block
@@ -1449,7 +1457,7 @@ QUESTION FOR HUMAN: [your question here]"""
     )
     for filename, code in pattern2:
         if filename.strip() not in test_files:
-            save_artifact(filename.strip(), code.strip())
+            save_source_file(filename.strip(), code.strip())
             test_files.append(filename.strip())
 
     # Determine if tests passed

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -1462,6 +1462,11 @@ QUESTION FOR HUMAN: [your question here]"""
             save_source_file(filename.strip(), code.strip())
             test_files.append(filename.strip())
 
+    if test_files:
+        git_commit(f"[tester] Tests: {', '.join(test_files)}")
+    else:
+        git_commit("[tester] Tests and usage documentation")
+
     # Determine if tests passed
     verdict = parse_verdict(response)
     verdict = apply_exit_gate(verdict, "tester")

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -35,8 +35,6 @@ from datetime import datetime
 from pathlib import Path
 
 from .agent import (
-    DEFAULT_WORKSPACE,
-    get_agents_dir,
     get_artifacts_dir,
     get_repo_root,
     get_sdlc_dir,
@@ -46,8 +44,6 @@ from .agent import (
     run_agent,
     set_repo_root,
     set_target_branch,
-    set_workspace,
-    setup_agent_workspace,
 )
 
 # Queue file handling for continuous mode
@@ -2431,7 +2427,6 @@ def main():
         print("  -h, --help            Show this help message and exit")
         print("  --version             Show version and exit")
         print("  --repo PATH           Path to code repository (default: CWD)")
-        print("  --workspace NAME      Named workspace (default: 'default')")
         print(
             "  --effort LEVEL        Effort level: minimal, moderate, maximum (default: moderate)"
         )
@@ -2544,7 +2539,6 @@ def main():
     continue_conversations = False
     continuous_mode = False
     queue_path = DEFAULT_QUEUE_PATH
-    workspace_name = DEFAULT_WORKSPACE
     effort = "moderate"  # default effort level
     no_questions = False  # disable all user prompts
     gitlab_issue_number = None  # GitLab issue to fetch
@@ -2561,11 +2555,6 @@ def main():
     if "--repo" in args:
         idx = args.index("--repo")
         repo_path = os.path.abspath(args[idx + 1])
-        args = args[:idx] + args[idx + 2 :]
-
-    if "--workspace" in args:
-        idx = args.index("--workspace")
-        workspace_name = args[idx + 1]
         args = args[:idx] + args[idx + 2 :]
 
     if "--effort" in args:
@@ -2661,9 +2650,6 @@ def main():
         idx = args.index("--gitlab-remote")
         gitlab_remote_url = args[idx + 1]
         args = args[:idx] + args[idx + 2 :]
-
-    # Set the workspace before any other operations
-    set_workspace(workspace_name)
 
     # Set the repo root (defaults to CWD)
     if repo_path:

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -36,17 +36,18 @@ from pathlib import Path
 
 from .agent import (
     DEFAULT_WORKSPACE,
-    LOG_FILE,
-    finalize_agent,
     get_agents_dir,
+    get_artifacts_dir,
+    get_repo_root,
+    get_sdlc_dir,
     get_target_branch,
-    get_workspace_dir,
-    get_workspace_name,
     log,
     log_separator,
     run_agent,
+    set_repo_root,
     set_target_branch,
     set_workspace,
+    setup_agent_workspace,
 )
 
 # Queue file handling for continuous mode
@@ -310,12 +311,13 @@ def github_fill_pr_template(
             diff_content += "\n... (diff truncated)"
         context_parts.append(f"## Git Diff\n```diff\n{diff_content}\n```")
 
-    plan_path = workspace / "PLAN.md"
+    artifacts = get_artifacts_dir()
+    plan_path = artifacts / "PLAN.md"
     if plan_path.exists():
         plan_content = plan_path.read_text()[:3000]
         context_parts.append(f"## PLAN.md\n{plan_content}")
 
-    review_path = workspace / "REVIEW.md"
+    review_path = artifacts / "REVIEW.md"
     if review_path.exists():
         review_content = review_path.read_text()[:2000]
         context_parts.append(f"## REVIEW.md\n{review_content}")
@@ -396,20 +398,21 @@ def gitlab_fill_mr_template(
             diff_content += "\n... (diff truncated)"
         context_parts.append(f"## Git Diff\n```diff\n{diff_content}\n```")
 
-    # PLAN.md
-    plan_path = workspace / "PLAN.md"
+    # PLAN.md (from artifacts)
+    artifacts = get_artifacts_dir()
+    plan_path = artifacts / "PLAN.md"
     if plan_path.exists():
         plan_content = plan_path.read_text()[:3000]
         context_parts.append(f"## PLAN.md\n{plan_content}")
 
-    # REVIEW.md
-    review_path = workspace / "REVIEW.md"
+    # REVIEW.md (from artifacts)
+    review_path = artifacts / "REVIEW.md"
     if review_path.exists():
         review_content = review_path.read_text()[:2000]
         context_parts.append(f"## REVIEW.md\n{review_content}")
 
-    # Test results if available
-    test_path = workspace / "tester" / "USAGE.md"
+    # Test results if available (from artifacts)
+    test_path = artifacts / "tester" / "USAGE.md"
     if test_path.exists():
         test_content = test_path.read_text()[:1500]
         context_parts.append(f"## Test Results\n{test_content}")
@@ -584,9 +587,15 @@ def pop_task_from_queue(queue_path: Path) -> str | None:
 
 
 def git_commit(message: str, files: list[str] | None = None) -> bool:
-    """Commit changes to git with the given message."""
+    """Commit source-code changes to git, excluding .sdlc-loop/.
+
+    Since SDLC artifacts live under .sdlc-loop/ (which is gitignored),
+    this only commits real source changes.  If there are no staged
+    changes after exclusion, it returns False.
+    """
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)
+    repo = get_repo_root()
 
     try:
         # Stage files
@@ -594,14 +603,14 @@ def git_commit(message: str, files: list[str] | None = None) -> bool:
             for f in files:
                 subprocess.run(
                     ["git", "add", f],
-                    cwd=get_workspace_dir(),
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
         else:
             subprocess.run(
-                ["git", "add", "-A"],
-                cwd=get_workspace_dir(),
+                ["git", "add", "-A", "--", ".", ":!.sdlc-loop/"],
+                cwd=repo,
                 env=env,
                 capture_output=True,
             )
@@ -609,7 +618,7 @@ def git_commit(message: str, files: list[str] | None = None) -> bool:
         # Check if there are changes to commit
         result = subprocess.run(
             ["git", "diff", "--cached", "--quiet"],
-            cwd=get_workspace_dir(),
+            cwd=repo,
             env=env,
             capture_output=True,
         )
@@ -620,7 +629,7 @@ def git_commit(message: str, files: list[str] | None = None) -> bool:
         # Commit
         subprocess.run(
             ["git", "commit", "-m", message],
-            cwd=get_workspace_dir(),
+            cwd=repo,
             env=env,
             capture_output=True,
         )
@@ -631,11 +640,11 @@ def git_commit(message: str, files: list[str] | None = None) -> bool:
 
 
 def load_env_file(env_path: str) -> bool:
-    """Copy a .env file to the workspace and load its variables.
+    """Load environment variables from a .env file.
 
-    The .env file is copied to the workspace root and its variables are
-    loaded into os.environ so agents inherit them. The .env file is added
-    to .gitignore to prevent committing secrets.
+    Reads the file and loads its variables into os.environ so agents
+    inherit them.  If the file is inside the repo, ensures .env is in
+    .gitignore.
 
     Returns True if successful, False otherwise.
     """
@@ -644,18 +653,11 @@ def load_env_file(env_path: str) -> bool:
         print(f"Error: .env file not found: {source}")
         return False
 
-    workspace = get_workspace_dir()
-    workspace.mkdir(parents=True, exist_ok=True)
+    print(f"Loading .env from {source}")
 
-    # Copy .env to workspace
-    dest = workspace / ".env"
-    import shutil
-
-    shutil.copy2(source, dest)
-    print(f"Copied {source} to {dest}")
-
-    # Add .env to .gitignore if not already there
-    gitignore = workspace / ".gitignore"
+    # Ensure .env is in .gitignore
+    repo = get_repo_root()
+    gitignore = repo / ".gitignore"
     gitignore_content = gitignore.read_text() if gitignore.exists() else ""
     if ".env" not in gitignore_content:
         with open(gitignore, "a") as f:
@@ -666,7 +668,7 @@ def load_env_file(env_path: str) -> bool:
 
     # Parse and load the .env file
     loaded_vars = []
-    with open(dest) as f:
+    with open(source) as f:
         for line in f:
             line = line.strip()
             # Skip empty lines and comments
@@ -692,380 +694,57 @@ def load_env_file(env_path: str) -> bool:
     return True
 
 
-def init_workspace():
-    """Initialize the workspace directory, agents directory, and git repo."""
-    get_workspace_dir().mkdir(parents=True, exist_ok=True)
-    # Pre-create agents directory to ensure it exists before any agent runs
-    get_agents_dir().mkdir(parents=True, exist_ok=True)
-    git_dir = get_workspace_dir() / ".git"
-    if not git_dir.exists():
-        env = os.environ.copy()
-        env.pop("CLAUDECODE", None)
-        subprocess.run(
-            ["git", "init"], cwd=get_workspace_dir(), env=env, capture_output=True
-        )
-        # Create initial commit
-        (get_workspace_dir() / ".gitkeep").touch()
-        subprocess.run(
-            ["git", "add", ".gitkeep"],
-            cwd=get_workspace_dir(),
-            env=env,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "commit", "-m", "Initialize workspace"],
-            cwd=get_workspace_dir(),
-            env=env,
-            capture_output=True,
-        )
+def init_sdlc_dir():
+    """Initialize the .sdlc-loop/ directory structure in the code repo.
 
+    Creates:
+      .sdlc-loop/agents/      - per-agent session directories
+      .sdlc-loop/artifacts/    - SDLC documents (plans, reviews, etc.)
+      .sdlc-loop/entries/      - iteration-ordered entries
+      .sdlc-loop/logs/         - log files
+      .sdlc-loop/pids/         - agent PID files
 
-def init_workspace_from(source: str) -> bool:
-    """Initialize a workspace by cloning from a git repository.
-
-    Accepts either a local path or a git URL. Clones the repo into the workspace
-    directory, preserving git history and remote configuration for pushing back.
-
-    Returns True if successful, False otherwise.
+    Also ensures .sdlc-loop/ is listed in the repo's .gitignore.
     """
-    workspace = get_workspace_dir()
-    agents_dir = get_agents_dir()
+    sdlc = get_sdlc_dir()
+    for subdir in ["agents", "artifacts", "entries", "logs", "pids"]:
+        (sdlc / subdir).mkdir(parents=True, exist_ok=True)
 
-    env = os.environ.copy()
-    env.pop("CLAUDECODE", None)
-
-    # Check if workspace already exists
-    if workspace.exists() and any(workspace.iterdir()):
-        existing = list(workspace.iterdir())
-        non_meta = [f for f in existing if f.name not in [".git", ".gitkeep"]]
-        if non_meta:
-            print(f"Error: Workspace '{get_workspace_name()}' already has content.")
-            print(f"  Location: {workspace}")
-            print(f"  Files: {[f.name for f in non_meta[:5]]}")
-            return False
-
-    # Ensure parent directories exist
-    workspace.parent.mkdir(parents=True, exist_ok=True)
-    agents_dir.mkdir(parents=True, exist_ok=True)
-
-    # Determine if source is a URL or local path
-    source_str = str(source)
-    is_url = source_str.startswith(("git@", "https://", "http://", "ssh://"))
-
-    if not is_url:
-        # Local path - convert to absolute and check it exists
-        source_path = Path(source).expanduser().resolve()
-        if not source_path.exists():
-            print(f"Error: Source path does not exist: {source_path}")
-            return False
-        # Check for regular repo (.git dir) or bare repo (HEAD file directly)
-        is_git_repo = (source_path / ".git").exists() or (source_path / "HEAD").exists()
-        if not is_git_repo:
-            print(f"Error: Source path is not a git repository: {source_path}")
-            return False
-        source_str = str(source_path)
-
-    print(f"Cloning {source_str} to workspace '{get_workspace_name()}'...")
-
-    # Clone the repository
-    result = subprocess.run(
-        ["git", "clone", source_str, str(workspace)],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    if result.returncode != 0:
-        print(f"Error: git clone failed: {result.stderr}")
-        return False
-
-    # Checkout the target branch (or create it if it doesn't exist)
-    target = get_target_branch()
-    # Check if branch exists on remote
-    result = subprocess.run(
-        ["git", "branch", "-r", "--list", f"origin/{target}"],
-        cwd=workspace,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-    if target != "main" and result.stdout.strip():
-        # Branch exists on remote, check it out
-        subprocess.run(
-            ["git", "checkout", target], cwd=workspace, env=env, capture_output=True
-        )
-    elif target != "main":
-        # Branch doesn't exist, create it from current HEAD
-        subprocess.run(
-            ["git", "checkout", "-b", target],
-            cwd=workspace,
-            env=env,
-            capture_output=True,
-        )
-    # else: stay on main (default after clone)
-
-    # For local repos (especially bare repos), copy their upstream remotes
-    # This allows glab to detect the GitLab project
-    if not is_url:
-        source_path = Path(source_str)
-        # Get remotes from source repo
-        remote_result = subprocess.run(
-            ["git", "remote", "-v"],
-            cwd=source_path,
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        if remote_result.returncode == 0:
-            # Parse remotes and find ones pointing to GitLab
-            for line in remote_result.stdout.strip().split("\n"):
-                if not line.strip():
-                    continue
-                parts = line.split()
-                if len(parts) >= 2:
-                    remote_name, remote_url = parts[0], parts[1]
-                    # Check if this points to GitLab (not a local path)
-                    if "gitlab" in remote_url.lower() or remote_url.startswith(
-                        ("git@", "https://", "ssh://")
-                    ):
-                        # Add this remote to workspace as "gitlab" if origin points locally
-                        existing = subprocess.run(
-                            ["git", "remote", "get-url", "gitlab"],
-                            cwd=workspace,
-                            env=env,
-                            capture_output=True,
-                        )
-                        if existing.returncode != 0:  # gitlab remote doesn't exist
-                            subprocess.run(
-                                ["git", "remote", "add", "gitlab", remote_url],
-                                cwd=workspace,
-                                env=env,
-                                capture_output=True,
-                            )
-                            print(f"  Added 'gitlab' remote: {remote_url}")
-                        break
-
-    # Strip any pre-existing SDLC artifacts from the cloned workspace
-    # This prevents dirty source repos from contaminating the workspace
-    import glob as glob_mod
-    dirty_artifacts = []
-    for pattern in ARTIFACT_PATTERNS:
-        for path in glob_mod.glob(str(workspace / pattern)):
-            dirty_artifacts.append(Path(path))
-    if dirty_artifacts:
-        for p in dirty_artifacts:
-            rel = str(p.relative_to(workspace))
-            if p.is_dir():
-                subprocess.run(["git", "rm", "-rf", rel],
-                             cwd=workspace, env=env, capture_output=True)
-            elif p.exists():
-                subprocess.run(["git", "rm", "-f", rel],
-                             cwd=workspace, env=env, capture_output=True)
-        subprocess.run(
-            ["git", "commit", "-m", "[ftl-sdlc-loop] Strip pre-existing SDLC artifacts"],
-            cwd=workspace, env=env, capture_output=True
-        )
-        print(f"  Stripped {len(dirty_artifacts)} pre-existing SDLC artifacts from clone")
-
-    print(f"Workspace '{get_workspace_name()}' cloned from {source_str}")
-    print(f"  Location: {workspace}")
-    print(f"  Branch: {target}")
-    print("  Use --push to push changes back when done")
-    return True
-
-
-ARTIFACT_PATTERNS = [
-    # Legacy non-versioned files
-    "TASK.md",
-    "PLAN.md",
-    "IMPLEMENTATION.md",
-    "REVIEW.md",
-    "USAGE.md",
-    "USER_FEEDBACK.md",
-    "FINAL_REPORT.md",
-    "CUMULATIVE_UNDERSTANDING.md",
-    # Versioned artifacts (PLAN_1.md, IMPLEMENTATION_1_2.md, etc.)
-    "PLAN_*.md",
-    "IMPLEMENTATION_*.md",
-    "REVIEW_*.md",
-    "TESTER_*.md",
-    "USER_FEEDBACK_*.md",
-    # Other patterns
-    "ITERATION_*.md",
-    "planner/",
-    "implementer/",
-    "reviewer/",
-    "user/",
-    "tester/USAGE.md",
-    "tester/*.md",  # Keep tester/test_*.py
-    "entries/iteration-*/",
-    "beliefs.md",
-    "nogoods.md",
-]
-
-
-def clean_workspace_artifacts(workspace: Path) -> None:
-    """Remove SDLC artifact files from workspace, archiving them first.
-
-    Moves any test_*.py files from tester/ to tests/ (fixing sys.path hacks),
-    archives all artifacts to logs/, then removes them from the git tree.
-    """
-    import glob
-    import tarfile
-    from datetime import datetime as dt
-
-    env = os.environ.copy()
-    env.pop("CLAUDECODE", None)
-
-    # Move tester/test_*.py to tests/ before cleanup
-    tester_dir = workspace / "tester"
-    tests_dir = workspace / "tests"
-    if tester_dir.exists():
-        test_files = list(tester_dir.glob("test_*.py"))
-        if test_files:
-            tests_dir.mkdir(parents=True, exist_ok=True)
-            for tf in test_files:
-                # Clean sys.path hacks from test files
-                content = tf.read_text()
-                cleaned_lines = []
-                for line in content.splitlines():
-                    if line.strip().startswith("sys.path.insert(") or (
-                        line.strip() == "import sys" and "sys.path.insert(" in content
-                    ):
-                        continue
-                    cleaned_lines.append(line)
-                dest = tests_dir / tf.name
-                if not dest.exists():
-                    dest.write_text("\n".join(cleaned_lines) + "\n")
-                    print(f"  Moved {tf.name} to tests/")
-                    subprocess.run(
-                        ["git", "add", str(dest.relative_to(workspace))],
-                        cwd=workspace,
-                        env=env,
-                        capture_output=True,
-                    )
-                # Remove original from tester/
-                tf.unlink()
-                subprocess.run(
-                    ["git", "rm", "-f", str(tf.relative_to(workspace))],
-                    cwd=workspace,
-                    env=env,
-                    capture_output=True,
-                )
-
-    # Find files that existed in the upstream repo before the loop started
-    # These should NOT be cleaned even if they match artifact patterns
-    upstream_files = set()
-    result = subprocess.run(
-        ["git", "log", "--diff-filter=A", "--name-only", "--pretty=format:"],
-        capture_output=True,
-        text=True,
-        cwd=workspace,
-        env=env,
-    )
-    # Files that existed before our first commit are NOT in the added-files list
-    # Simpler: check what exists on the base branch (origin/main or gitlab/main)
-    for remote in ["origin/main", "gitlab/main", "origin/master", "gitlab/master"]:
-        result = subprocess.run(
-            ["git", "ls-tree", "-r", "--name-only", remote],
-            capture_output=True,
-            text=True,
-            cwd=workspace,
-            env=env,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            upstream_files = set(result.stdout.strip().splitlines())
-            break
-
-    # Collect all artifact files that exist, excluding upstream files
-    artifact_files = []
-    for pattern in ARTIFACT_PATTERNS:
-        for path in glob.glob(str(workspace / pattern)):
-            rel = str(Path(path).relative_to(workspace))
-            # Skip files/dirs that existed in upstream
-            if rel in upstream_files:
-                continue
-            # For directories, check if any file inside existed upstream
-            if Path(path).is_dir():
-                has_upstream = any(f.startswith(rel + "/") for f in upstream_files)
-                if has_upstream:
-                    continue
-            artifact_files.append(Path(path))
-
-    if not artifact_files:
-        print("No artifacts to clean.")
-        return
-
-    # Archive before removing
-    logs_dir = Path.cwd() / "logs"
-    logs_dir.mkdir(parents=True, exist_ok=True)
-
-    timestamp = dt.now().strftime("%Y%m%d_%H%M%S")
-    workspace_name = get_workspace_name()
-    tarball_name = f"{workspace_name}_{timestamp}_artifacts.tar.gz"
-    tarball_path = logs_dir / tarball_name
-
-    print(f"Archiving {len(artifact_files)} artifact files to {tarball_path}...")
-    with tarfile.open(tarball_path, "w:gz") as tar:
-        for artifact_path in artifact_files:
-            arcname = artifact_path.relative_to(workspace)
-            if artifact_path.is_dir():
-                tar.add(artifact_path, arcname=arcname)
-            elif artifact_path.exists():
-                tar.add(artifact_path, arcname=arcname)
-    print(f"  Archived to: {tarball_path}")
-
-    # Remove artifact files from git but keep on disk
-    print(f"Cleaning {len(artifact_files)} artifact files from git...")
-    for p in artifact_files:
-        rel = str(p.relative_to(workspace))
-        if p.is_dir():
-            subprocess.run(
-                ["git", "rm", "-rf", "--cached", rel],
-                cwd=workspace,
-                env=env,
-                capture_output=True,
-            )
-        elif p.exists():
-            subprocess.run(
-                ["git", "rm", "-f", "--cached", rel],
-                cwd=workspace,
-                env=env,
-                capture_output=True,
-            )
-
-    # Remove empty tester/ directory
-    if tester_dir.exists() and not any(tester_dir.iterdir()):
-        tester_dir.rmdir()
-        subprocess.run(
-            ["git", "rm", "-rf", "tester"], cwd=workspace, env=env, capture_output=True
-        )
+    # Ensure .sdlc-loop/ is gitignored
+    repo = get_repo_root()
+    gitignore = repo / ".gitignore"
+    gitignore_content = gitignore.read_text() if gitignore.exists() else ""
+    if ".sdlc-loop/" not in gitignore_content:
+        with open(gitignore, "a") as f:
+            if gitignore_content and not gitignore_content.endswith("\n"):
+                f.write("\n")
+            f.write(".sdlc-loop/\n")
+        print("Added .sdlc-loop/ to .gitignore")
 
 
 def push_workspace(
     branch: str = "main", create_pr: bool = False, squash: bool = True
 ) -> bool:
-    """Push workspace changes back to the remote repository.
+    """Push repo changes to the remote.
 
-    Cleans up artifact files, squashes commits, and pushes.
-    Optionally creates a pull request instead of pushing directly.
+    Squashes commits and pushes.  SDLC artifacts are already gitignored
+    so no cleanup is needed.  Optionally creates a pull request instead
+    of pushing directly.
 
     Returns True if successful, False otherwise.
     """
-    workspace = get_workspace_dir()
+    repo = get_repo_root()
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)
 
-    if not workspace.exists() or not (workspace / ".git").exists():
-        print(f"Error: Workspace '{get_workspace_name()}' is not a git repository")
+    if not repo.exists() or not (repo / ".git").exists():
+        print(f"Error: {repo} is not a git repository")
         return False
 
-    # Read task description before cleanup deletes TASK.md
-    # Format is: "# Task\n\n{description}\n\nStarted: {timestamp}"
-    task_file = workspace / "TASK.md"
+    # Read task description from artifacts
+    task_file = get_artifacts_dir() / "TASK.md"
     if task_file.exists():
         lines = task_file.read_text().strip().splitlines()
-        # Skip header and blank lines, stop before "Started:" metadata
         desc_lines = [
             l
             for l in lines
@@ -1075,31 +754,10 @@ def push_workspace(
     else:
         task_desc = "ftl-sdlc-loop changes"
 
-    clean_workspace_artifacts(workspace)
-
-    # Check for any uncommitted changes (including deletions)
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
-        cwd=workspace,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-    if result.stdout.strip():
-        subprocess.run(
-            ["git", "add", "-A"], cwd=workspace, env=env, capture_output=True
-        )
-        subprocess.run(
-            ["git", "commit", "-m", "[ftl-sdlc-loop] Clean up artifacts"],
-            cwd=workspace,
-            env=env,
-            capture_output=True,
-        )
-
     # Get current branch
     result = subprocess.run(
         ["git", "branch", "--show-current"],
-        cwd=workspace,
+        cwd=repo,
         env=env,
         capture_output=True,
         text=True,
@@ -1109,7 +767,7 @@ def push_workspace(
     # Find the original commit before ftl-sdlc-loop started
     result = subprocess.run(
         ["git", "log", "--oneline", f"origin/{branch}..HEAD"],
-        cwd=workspace,
+        cwd=repo,
         env=env,
         capture_output=True,
         text=True,
@@ -1118,10 +776,9 @@ def push_workspace(
 
     if squash and commit_count > 1:
         print(f"Squashing {commit_count} commits...")
-        # Soft reset to origin and recommit
         subprocess.run(
             ["git", "reset", "--soft", f"origin/{branch}"],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
         )
@@ -1130,28 +787,27 @@ def push_workspace(
                 "git",
                 "commit",
                 "-m",
-                f"{task_desc}\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>",
+                f"{task_desc}\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>",
             ],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
         )
 
-    # Check if there are actual changes after cleanup
+    # Check if there are actual changes
     diff_check = subprocess.run(
         ["git", "diff", "--stat", f"origin/{branch}..HEAD"],
-        cwd=workspace, env=env, capture_output=True, text=True
+        cwd=repo, env=env, capture_output=True, text=True
     )
     if not diff_check.stdout.strip():
-        print("No code changes to push — only SDLC artifacts were present.")
+        print("No code changes to push.")
         return False
 
     if create_pr:
-        # Push the working branch and create a PR
         print(f"Pushing {current_branch} branch...")
         result = subprocess.run(
             ["git", "push", "-u", "origin", current_branch],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
             text=True,
@@ -1163,7 +819,7 @@ def push_workspace(
         print("Creating pull request...")
         result = subprocess.run(
             ["gh", "pr", "create", "--fill", "--base", branch],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
             text=True,
@@ -1176,14 +832,13 @@ def push_workspace(
         print(f"Pull request created: {result.stdout.strip()}")
         return True
     else:
-        # Merge into target branch and push directly
         print(f"Merging {current_branch} into {branch}...")
         subprocess.run(
-            ["git", "checkout", branch], cwd=workspace, env=env, capture_output=True
+            ["git", "checkout", branch], cwd=repo, env=env, capture_output=True
         )
         result = subprocess.run(
             ["git", "merge", current_branch, "--no-edit"],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
             text=True,
@@ -1195,7 +850,7 @@ def push_workspace(
         print(f"Pushing to origin/{branch}...")
         result = subprocess.run(
             ["git", "push", "origin", branch],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
             text=True,
@@ -1209,8 +864,9 @@ def push_workspace(
 
 
 def save_artifact(name: str, content: str) -> Path:
-    """Save an artifact to the workspace."""
-    path = get_workspace_dir() / name
+    """Save an artifact to .sdlc-loop/artifacts/."""
+    path = get_artifacts_dir() / name
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     return path
 
@@ -1322,7 +978,7 @@ def save_entry(
         content: Content to save
         inner: Inner loop iteration (for reviewer/implementer cycles)
     """
-    entry_dir = get_workspace_dir() / "entries" / f"iteration-{iteration}"
+    entry_dir = get_sdlc_dir() / "entries" / f"iteration-{iteration}"
     entry_dir.mkdir(parents=True, exist_ok=True)
     if inner is not None:
         path = entry_dir / f"{role}_{inner}.md"
@@ -1339,29 +995,22 @@ from beliefs_lib.parser import append_claim, parse_nogoods, parse_registry
 
 
 def _beliefs_registry_path() -> Path:
-    return get_workspace_dir() / "beliefs.md"
+    return get_sdlc_dir() / "beliefs.md"
 
 
 def _beliefs_nogoods_path() -> Path:
-    return get_workspace_dir() / "nogoods.md"
+    return get_sdlc_dir() / "nogoods.md"
 
 
 def beliefs_init():
-    """Initialize beliefs.md and nogoods.md in the workspace if they don't exist."""
+    """Initialize beliefs.md and nogoods.md under .sdlc-loop/ if they don't exist."""
     registry = _beliefs_registry_path()
     nogoods = _beliefs_nogoods_path()
-    created = False
+    registry.parent.mkdir(parents=True, exist_ok=True)
     if not registry.exists():
         registry.write_text("# Beliefs Registry\n\n## Repos\n\n")
-        created = True
     if not nogoods.exists():
         nogoods.write_text("# Nogoods\n\n")
-        created = True
-    if created:
-        git_commit(
-            "[supervisor] Initialize beliefs registry",
-            files=["beliefs.md", "nogoods.md"],
-        )
 
 
 def beliefs_add(
@@ -1497,12 +1146,11 @@ QUESTION FOR HUMAN: [your question here]"""
         "planner", prompt, continue_session=(continue_conversations or iteration > 1)
     )
 
-    # Save plan to workspace (versioned by iteration)
+    # Save plan to artifacts (versioned by iteration)
     save_artifact(
         f"PLAN_{iteration}.md",
         f"# Plan (Iteration {iteration})\n\nTask: {task}\n\n{response}",
     )
-    git_commit(f"[planner] Plan for: {task[:50]}...")
 
     return {
         "output": response,
@@ -1531,13 +1179,13 @@ Address the reviewer's concerns in your implementation.
 """
 
     # Phase 1: Make the actual changes — no prose, just tool calls
-    workspace = get_workspace_dir()
+    repo = get_repo_root()
     implement_prompt = f"""You are a software implementer. Your ONLY job right now is to
 make code changes using the Edit and Write tools. Do NOT write prose or
 documentation. Do NOT create markdown files. Just find the files and edit them.
 
-You are running in the SOURCE TREE of the project at: {workspace}
-IMPORTANT: Only modify files inside {workspace}. Do NOT modify files outside this directory.
+You are running in the SOURCE TREE of the project at: {repo}
+IMPORTANT: Only modify files inside {repo}. Do NOT modify files outside this directory.
 
 Steps:
 1. Use Glob/Grep to find the files mentioned in the plan
@@ -1690,9 +1338,6 @@ QUESTION FOR HUMAN: [your question here]"""
         "reviewer", prompt, continue_session=(continue_conversations or iteration > 1)
     )
 
-    # Note: versioned artifact save happens in run_iteration()
-    git_commit("[reviewer] Code review complete")
-
     verdict = parse_verdict(response)
     verdict = apply_exit_gate(verdict, "reviewer")
 
@@ -1715,13 +1360,13 @@ def tester(
     Provides usage instructions to the User agent.
     Includes self-review.
     """
-    workspace = get_workspace_dir()
+    repo = get_repo_root()
     prompt = f"""You are a QA tester. Your job is to:
 1. Create tests for this implementation
 2. Document HOW TO USE the software for the User
 
-You are running in the SOURCE TREE of the project at: {workspace}
-IMPORTANT: Only modify files inside {workspace}. Do NOT modify files outside this directory.
+You are running in the SOURCE TREE of the project at: {repo}
+IMPORTANT: Only modify files inside {repo}. Do NOT modify files outside this directory.
 
 Test files should be created alongside the existing test infrastructure — use Glob to find
 where existing tests live (e.g. `**/tests/**/test_*.py`) and put new
@@ -1810,9 +1455,6 @@ QUESTION FOR HUMAN: [your question here]"""
         if filename.strip() not in test_files:
             save_artifact(filename.strip(), code.strip())
             test_files.append(filename.strip())
-
-    # Note: versioned artifact save happens in run_iteration()
-    git_commit("[tester] Tests and usage documentation")
 
     # Determine if tests passed
     verdict = parse_verdict(response)
@@ -1903,7 +1545,6 @@ QUESTION FOR HUMAN: [your question here]"""
         f"USER_FEEDBACK_{iteration}.md",
         f"# User Feedback (Iteration {iteration})\n\n{response}",
     )
-    git_commit("[user] User feedback and feature requests")
 
     verdict = parse_verdict(response)
     verdict = apply_exit_gate(verdict, "user")
@@ -1918,20 +1559,13 @@ QUESTION FOR HUMAN: [your question here]"""
 def process_agent_output(
     agent_name: str, output: str, iteration: int, no_questions: bool = False
 ) -> str:
-    """Process agent output, checking for escalations, then merge to target branch."""
+    """Process agent output, checking for escalations."""
     escalation = check_for_escalation(output)
     if escalation:
         human_response = request_human_input(
             agent_name, escalation, iteration, no_questions
         )
         output += f"\n\n## Human Response\n\n{human_response}"
-
-    # Merge agent's branch back to target branch
-    if finalize_agent(agent_name):
-        print(f"  [Merged {agent_name} branch to {get_target_branch()}]")
-    else:
-        print(f"  [WARNING: Failed to merge {agent_name} branch to {get_target_branch()}]")
-        print(f"  Code changes from {agent_name} may be lost!")
 
     return output
 
@@ -1975,7 +1609,6 @@ def run_iteration(
             f"PLAN_{iteration}.md",
             f"# Plan (Provided, Iteration {iteration})\n\nTask: {task}\n\n{existing_plan}",
         )
-        git_commit(f"[planner] Using provided plan for: {task[:50]}...")
         save_entry(iteration, "planner", results["planner"])
         print(f"\n{results['planner'][:500]}...\n")
     else:
@@ -2354,7 +1987,6 @@ Verdict: {'SATISFIED' if results['user_satisfied'] else 'NEEDS_IMPROVEMENT'}
     summary_path = save_artifact(
         f"ITERATION_{iteration}_HUMAN_REVIEW.md", human_summary
     )
-    git_commit(f"[supervisor] Iteration {iteration} complete - ready for human review")
 
     print(f"\n{'='*60}")
     print(f"ITERATION {iteration} COMPLETE - HUMAN REVIEW REQUESTED")
@@ -2384,7 +2016,7 @@ def load_understanding(understanding_path: str | Path) -> str:
 
 def check_human_comments(iteration: int) -> str | None:
     """Check if human added comments to the review document."""
-    review_path = get_workspace_dir() / f"ITERATION_{iteration}_HUMAN_REVIEW.md"
+    review_path = get_artifacts_dir() / f"ITERATION_{iteration}_HUMAN_REVIEW.md"
     if not review_path.exists():
         return None
 
@@ -2434,7 +2066,7 @@ def request_human_input(
     print(f"\n{escalation['message']}\n")
 
     # Save escalation to file
-    escalation_path = get_workspace_dir() / f"ESCALATION_{iteration}_{agent_name}.md"
+    escalation_path = get_artifacts_dir() / f"ESCALATION_{iteration}_{agent_name}.md"
     escalation_content = f"""# Escalation from {agent_name}
 
 ## Agent's Question/Issue
@@ -2477,7 +2109,6 @@ def request_human_input(
         # Update file with response
         escalation_content += response
         escalation_path.write_text(escalation_content)
-        git_commit(f"[human] Response to {agent_name} escalation")
         return response
 
     # Check if they edited the file instead
@@ -2485,7 +2116,6 @@ def request_human_input(
     if "## Human Response" in content:
         response = content.split("## Human Response")[-1].strip()
         if response:
-            git_commit(f"[human] Response to {agent_name} escalation")
             return response
 
     return "(No response provided - agent should proceed with best judgment)"
@@ -2517,10 +2147,9 @@ def run_pipeline(
     log(f"Max iterations: {max_iterations}")
     log(f"Continue conversations: {continue_conversations}")
     log(f"Understanding path: {understanding_path}")
-    log(f"Log file: {LOG_FILE}")
 
-    # Initialize workspace with git
-    init_workspace()
+    # Initialize .sdlc-loop/ directory structure
+    init_sdlc_dir()
 
     # Initialize beliefs system if available
     beliefs_init()
@@ -2531,9 +2160,8 @@ def run_pipeline(
         shared_understanding = load_understanding(understanding_path)
         if shared_understanding:
             print(f"Loaded shared understanding from: {understanding_path}")
-            # Save to workspace for reference
+            # Save to artifacts for reference
             save_artifact("SHARED_UNDERSTANDING.md", shared_understanding)
-            git_commit("[supervisor] Import shared understanding")
         else:
             print(f"Warning: No understanding found at: {understanding_path}")
 
@@ -2542,14 +2170,14 @@ def run_pipeline(
     print(f"TASK: {task}")
     print(f"EFFORT LEVEL: {effort} - {effort_config['description']}")
     print(f"MAX ITERATIONS: {max_iterations}")
-    print(f"get_workspace_dir(): {get_workspace_dir()}")
+    print(f"Repo root: {get_repo_root()}")
+    print(f"SDLC dir: {get_sdlc_dir()}")
     print("=" * 60)
 
-    # Save task to workspace
+    # Save task to artifacts
     save_artifact(
         "TASK.md", f"# Task\n\n{task}\n\nStarted: {datetime.now().isoformat()}"
     )
-    git_commit(f"[supervisor] Start task: {task[:50]}...")
 
     # Plan-only mode: run planner and exit
     if plan_only:
@@ -2559,15 +2187,14 @@ def run_pipeline(
         )
         plan_output = plan_result["output"]
         save_artifact("PLAN.md", f"# Plan\n\nTask: {task}\n\n{plan_output}")
-        git_commit(f"[planner] Plan for: {task[:50]}...")
         print(f"\n{plan_output}\n")
         print(f"\n{'='*60}")
         print("PLAN-ONLY MODE COMPLETE")
-        print(f"Plan saved to: {get_workspace_dir() / 'PLAN.md'}")
+        print(f"Plan saved to: {get_artifacts_dir() / 'PLAN.md'}")
         print("Review the plan, then run with --plan PLAN.md to continue")
         print("=" * 60)
         return {
-            "workspace": str(get_workspace_dir()),
+            "repo": str(get_repo_root()),
             "iterations": 0,
             "final_satisfied": False,
             "plan_only": True,
@@ -2617,9 +2244,9 @@ def run_pipeline(
             user_feedback = results["user"]
 
             # Update cumulative understanding with learnings
-            cumulative_path = get_workspace_dir() / "CUMULATIVE_UNDERSTANDING.md"
+            cumulative_path = get_artifacts_dir() / "CUMULATIVE_UNDERSTANDING.md"
             iteration_understanding = (
-                get_workspace_dir() / f"ITERATION_{iteration}_UNDERSTANDING.md"
+                get_artifacts_dir() / f"ITERATION_{iteration}_UNDERSTANDING.md"
             ).read_text()
 
             if cumulative_path.exists():
@@ -2629,9 +2256,6 @@ def run_pipeline(
                 cumulative = f"# Cumulative Understanding\n\nLearnings accumulated across iterations.\n\n---\n\n{iteration_understanding}"
 
             cumulative_path.write_text(cumulative)
-            git_commit(
-                f"[supervisor] Update cumulative understanding after iteration {iteration}"
-            )
     else:
         print("\n" + "=" * 60)
         print("SUPERVISOR: Max iterations reached")
@@ -2688,9 +2312,9 @@ See `CUMULATIVE_UNDERSTANDING.md` for full learnings across all iterations.
 """
         if all_results[-1]["user_satisfied"]:
             final_summary += """The User agent is satisfied. Human should review:
-1. Generated code in workspace/
+1. Generated code in the repo
 2. Test files (test_*.py)
-3. Usage documentation (USAGE.md)
+3. SDLC artifacts in .sdlc-loop/artifacts/
 
 If changes are needed, run another iteration with feedback.
 """
@@ -2700,14 +2324,13 @@ If changes are needed, run another iteration with feedback.
 2. Provide additional context/understanding
 3. Manually address the remaining issues
 
-To continue: `uv run supervisor.py --understanding workspace/ "task" --max-iterations N`
+To continue: `uv run supervisor.py --understanding .sdlc-loop/artifacts/ "task" --max-iterations N`
 """
 
     save_artifact("FINAL_REPORT.md", final_summary)
-    git_commit(f"[supervisor] Task {final_status.lower()} - final report ready")
 
     print(f"\n{'='*60}")
-    print("FINAL REPORT: workspace/FINAL_REPORT.md")
+    print(f"FINAL REPORT: {get_artifacts_dir() / 'FINAL_REPORT.md'}")
     print(f"{'='*60}")
 
     return {
@@ -2715,7 +2338,7 @@ To continue: `uv run supervisor.py --understanding workspace/ "task" --max-itera
         "iterations": len(all_results),
         "results": all_results,
         "final_satisfied": all_results[-1]["user_satisfied"] if all_results else False,
-        "workspace": str(get_workspace_dir()),
+        "repo": str(get_repo_root()),
     }
 
 
@@ -2807,6 +2430,7 @@ def main():
         print("\nOptions:")
         print("  -h, --help            Show this help message and exit")
         print("  --version             Show version and exit")
+        print("  --repo PATH           Path to code repository (default: CWD)")
         print("  --workspace NAME      Named workspace (default: 'default')")
         print(
             "  --effort LEVEL        Effort level: minimal, moderate, maximum (default: moderate)"
@@ -2822,10 +2446,7 @@ def main():
             "  --continuous          Run in continuous mode, processing tasks from a queue file"
         )
         print("  --queue PATH          Path to queue file (default: queue.txt)")
-        print(
-            "  --init-from PATH|URL  Clone repo into workspace (local path or git URL)"
-        )
-        print("  --env PATH            Copy .env file to workspace and load variables")
+        print("  --env PATH            Load .env file variables")
         print(
             "  --prompt-file PATH    Read task description from file instead of command line"
         )
@@ -2834,16 +2455,13 @@ def main():
         )
         print("  --plan PATH           Use existing plan file, skip planner stage")
         print(
-            "  --push                Push workspace changes (archives artifacts to logs/)"
+            "  --push                Push changes to remote"
         )
         print(
             "  --pr                  Create a GitHub pull request instead of pushing directly"
         )
         print(
             "  --no-squash           Don't squash commits when pushing (default: squash)"
-        )
-        print(
-            "  --clean               Strip SDLC artifacts before push/PR/MR (or standalone)"
         )
         print(
             "  --no-questions        Disable all interactive prompts (auto-respond with defaults)"
@@ -2871,7 +2489,7 @@ def main():
         print(
             "  --gitlab-mr           Create GitLab merge request after successful run"
         )
-        print("  --gitlab-remote URL   Add GitLab remote (for bare repo workflows)")
+        print("  --gitlab-remote URL   Add GitLab remote")
         print("\nEffort levels:")
         print("  minimal  - Fast (~5-15 min): working solution, basic tests")
         print(
@@ -2880,37 +2498,25 @@ def main():
         print("  maximum  - Production (~2-3 hours): comprehensive testing & docs")
         print("\nThe loop runs autonomously. Human reviews FINAL_REPORT.md at the end.")
         print("\nExamples:")
-        print(
-            f"  {sys.argv[0]} --workspace iris --init-from /path/to/iris  # Clone local repo"
-        )
-        print(
-            f"  {sys.argv[0]} --workspace iris --init-from git@github.com:user/repo.git"
-        )
-        print(
-            f"  {sys.argv[0]} --workspace iris 'add a new feature'        # Work on it"
-        )
-        print(
-            f"  {sys.argv[0]} --workspace iris --push                     # Push changes back"
-        )
-        print(
-            f"  {sys.argv[0]} --workspace iris --pr                       # Create a PR instead"
-        )
         print(f"  {sys.argv[0]} 'write a function to calculate fibonacci numbers'")
+        print(f"  {sys.argv[0]} --repo /path/to/myproject 'add a new feature'")
+        print(f"  {sys.argv[0]} --push                     # Push changes")
+        print(f"  {sys.argv[0]} --pr                       # Create a PR")
         print(f"  {sys.argv[0]} --max-iterations 5 'complex feature'")
         print(f"  {sys.argv[0]} --continue 'fix the bug identified in the last run'")
         print("\nGitHub workflow:")
         print(
-            f"  {sys.argv[0]} --workspace issue-42 --init-from ~/repo.git --github-issue 42"
+            f"  {sys.argv[0]} --repo ~/myproject --github-issue 42"
         )
         print(
-            f"  {sys.argv[0]} --workspace issue-42 --github-pr --push    # Push and create PR"
+            f"  {sys.argv[0]} --github-pr --push    # Push and create PR"
         )
-        print("\nGitLab workflow (bare repo):")
+        print("\nGitLab workflow:")
         print(
-            f"  {sys.argv[0]} --workspace issue-285 --init-from ~/repo.git --gitlab-remote git@gitlab.com:org/repo.git --gitlab-issue 285"
+            f"  {sys.argv[0]} --repo ~/myproject --gitlab-issue 285"
         )
         print(
-            f"  {sys.argv[0]} --workspace issue-285 --gitlab-mr --push   # Push and create MR"
+            f"  {sys.argv[0]} --gitlab-mr --push   # Push and create MR"
         )
         print("\nContinuous mode:")
         print(f"  {sys.argv[0]} --continuous")
@@ -2923,109 +2529,12 @@ def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <task description> [options]")
         print(f"       {sys.argv[0]} --continuous [options]")
-        print("\nOptions:")
-        print("  --workspace NAME      Named workspace (default: 'default')")
-        print(
-            "  --effort LEVEL        Effort level: minimal, moderate, maximum (default: moderate)"
-        )
-        print(
-            "  --max-iterations N    Maximum development iterations (default: from effort level)"
-        )
-        print("  --understanding PATH  Path to understanding file or directory")
-        print(
-            "  --continue            Continue previous agent conversations (for follow-up runs)"
-        )
-        print(
-            "  --continuous          Run in continuous mode, processing tasks from a queue file"
-        )
-        print("  --queue PATH          Path to queue file (default: queue.txt)")
-        print(
-            "  --init-from PATH|URL  Clone repo into workspace (local path or git URL)"
-        )
-        print("  --env PATH            Copy .env file to workspace and load variables")
-        print(
-            "  --prompt-file PATH    Read task description from file instead of command line"
-        )
-        print(
-            "  --plan-only           Run planner only, save plan, and exit for review"
-        )
-        print("  --plan PATH           Use existing plan file, skip planner stage")
-        print(
-            "  --push                Push workspace changes (archives artifacts to logs/)"
-        )
-        print(
-            "  --pr                  Create a GitHub pull request instead of pushing directly"
-        )
-        print(
-            "  --no-squash           Don't squash commits when pushing (default: squash)"
-        )
-        print(
-            "  --clean               Strip SDLC artifacts before push/PR/MR (or standalone)"
-        )
-        print(
-            "  --no-questions        Disable all interactive prompts (auto-respond with defaults)"
-        )
-        print(
-            "  --branch NAME         Working branch for feature development (default: main)"
-        )
-        print("  --github-issue NUM    Fetch GitHub issue and use as task prompt")
-        print(
-            "  --github-repo SLUG    GitHub repo (owner/repo) for issue fetch (auto-detected if omitted)"
-        )
-        print("  --github-pr           Create GitHub pull request after successful run")
-        print(
-            "  --code-review         Run code-review review-loop after PR creation (requires --github-pr)"
-        )
-        print("  --beliefs PATH        Beliefs file for code-review (from code-expert)")
-        print(
-            "  --review-model NAME   Model for code-review (repeatable, default: claude + gemini)"
-        )
-        print(
-            "  --gitlab-issue NUM    Fetch GitLab issue, assign to self, use as task prompt"
-        )
-        print(
-            "  --gitlab-mr           Create GitLab merge request after successful run"
-        )
-        print("  --gitlab-remote URL   Add GitLab remote (for bare repo workflows)")
-        print("\nEffort levels:")
-        print("  minimal  - Fast (~5-15 min): working solution, basic tests")
-        print(
-            "  moderate - Balanced (~30-60 min): good practices, decent tests (default)"
-        )
-        print("  maximum  - Production (~2-3 hours): comprehensive testing & docs")
-        print("\nThe loop runs autonomously. Human reviews FINAL_REPORT.md at the end.")
+        print("\nRun with -h or --help for full options.")
         print("\nExamples:")
-        print(
-            f"  {sys.argv[0]} --workspace iris --init-from /path/to/iris  # Initialize workspace"
-        )
-        print(
-            f"  {sys.argv[0]} --workspace iris 'add a new feature'        # Work on it"
-        )
         print(f"  {sys.argv[0]} 'write a function to calculate fibonacci numbers'")
-        print(f"  {sys.argv[0]} --workspace myproject 'add a new feature'")
-        print(
-            f"  {sys.argv[0]} --understanding workspace/SHARED_UNDERSTANDING.md 'build the feature'"
-        )
-        print(
-            f"  {sys.argv[0]} --understanding ./context/ 'build feature'  # directory of docs"
-        )
-        print(f"  {sys.argv[0]} --max-iterations 5 'complex feature'")
-        print(f"  {sys.argv[0]} --continue 'fix the bug identified in the last run'")
-        print("\nGitHub workflow:")
-        print(
-            f"  {sys.argv[0]} --workspace issue-42 --init-from ~/repo.git --github-issue 42"
-        )
-        print(
-            f"  {sys.argv[0]} --workspace issue-42 --github-pr --push    # Push and create PR"
-        )
-        print("\nGitLab workflow (bare repo):")
-        print(
-            f"  {sys.argv[0]} --workspace issue-285 --init-from ~/repo.git --gitlab-remote git@gitlab.com:org/repo.git --gitlab-issue 285"
-        )
-        print("\nContinuous mode:")
+        print(f"  {sys.argv[0]} --repo /path/to/project 'add a new feature'")
+        print(f"  {sys.argv[0]} --github-issue 42")
         print(f"  {sys.argv[0]} --continuous")
-        print(f"  {sys.argv[0]} --continuous --queue my_tasks.txt")
-        print(f"  {sys.argv[0]} --continuous --max-iterations 5")
         sys.exit(1)
 
     # Parse args
@@ -3046,9 +2555,13 @@ def main():
     code_review = False  # Run code-review after PR creation
     beliefs_path = None  # Beliefs file for code-review
     review_models = []  # Models to use for code-review (e.g. claude, gemini)
-    init_from_path = None  # Local repo path from --init-from
-    clean_artifacts = False  # Strip SDLC artifacts before push
+    repo_path = None  # Code repo path from --repo
     branch_name = None  # Override branch name
+
+    if "--repo" in args:
+        idx = args.index("--repo")
+        repo_path = os.path.abspath(args[idx + 1])
+        args = args[:idx] + args[idx + 2 :]
 
     if "--workspace" in args:
         idx = args.index("--workspace")
@@ -3137,11 +2650,6 @@ def main():
         review_models.append(args[idx + 1])
         args = args[:idx] + args[idx + 2 :]
 
-    if "--clean" in args:
-        idx = args.index("--clean")
-        clean_artifacts = True
-        args = args[:idx] + args[idx + 1 :]
-
     if "--branch" in args:
         idx = args.index("--branch")
         branch_name = args[idx + 1]
@@ -3157,50 +2665,36 @@ def main():
     # Set the workspace before any other operations
     set_workspace(workspace_name)
 
-    # Set the target branch for agent merges (default: main)
+    # Set the repo root (defaults to CWD)
+    if repo_path:
+        set_repo_root(Path(repo_path))
+
+    # Set the target branch (default: main)
     if branch_name:
         set_target_branch(branch_name)
 
-    # Handle --init-from early (initialize workspace, then continue if task provided)
-    if "--init-from" in args:
-        idx = args.index("--init-from")
-        source = args[idx + 1]  # Can be path or URL
-        args = args[:idx] + args[idx + 2 :]
-        if os.path.isdir(source):
-            init_from_path = os.path.abspath(source)
-        success = init_workspace_from(source)
-        if not success:
-            sys.exit(1)
-        # Add GitLab remote if specified (for bare repo workflows)
-        workspace = get_workspace_dir()
-        env = os.environ.copy()
-        env.pop("CLAUDECODE", None)
-        if gitlab_remote_url:
-            subprocess.run(
-                ["git", "remote", "add", "gitlab", gitlab_remote_url],
-                cwd=workspace,
-                env=env,
-                capture_output=True,
-            )
-            print(f"  Added 'gitlab' remote: {gitlab_remote_url}")
-        # If GitHub repo is specified, update origin to point to GitHub
-        # (when --init-from is a local path, origin points locally)
-        if github_issue_repo:
-            github_url = f"git@github.com:{github_issue_repo}.git"
-            subprocess.run(
-                ["git", "remote", "set-url", "origin", github_url],
-                cwd=workspace,
-                env=env,
-                capture_output=True,
-            )
-            print(f"  Set origin to: {github_url}")
-        if (
-            not args
-            and not gitlab_issue_number
-            and not github_issue_number
-            and not continuous_mode
-        ):
-            sys.exit(0)
+    # Add GitLab remote if specified
+    repo = get_repo_root()
+    env = os.environ.copy()
+    env.pop("CLAUDECODE", None)
+    if gitlab_remote_url:
+        subprocess.run(
+            ["git", "remote", "add", "gitlab", gitlab_remote_url],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+        )
+        print(f"  Added 'gitlab' remote: {gitlab_remote_url}")
+    # If GitHub repo is specified, update origin
+    if github_issue_repo:
+        github_url = f"git@github.com:{github_issue_repo}.git"
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", github_url],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+        )
+        print(f"  Set origin to: {github_url}")
 
     # Handle --env early (load environment variables before running agents)
     if "--env" in args:
@@ -3210,45 +2704,6 @@ def main():
         success = load_env_file(env_path)
         if not success:
             sys.exit(1)
-
-    # Handle --clean as standalone command (clean artifacts without pushing)
-    if (
-        clean_artifacts
-        and "--push" not in args
-        and "--pr" not in args
-        and not github_pr
-        and not gitlab_mr
-        and not github_issue_number
-        and not gitlab_issue_number
-    ):
-        workspace = get_workspace_dir()
-        if not workspace.exists() or not (workspace / ".git").exists():
-            print(f"Error: Workspace '{get_workspace_name()}' is not a git repository")
-            sys.exit(1)
-        env = os.environ.copy()
-        env.pop("CLAUDECODE", None)
-        clean_workspace_artifacts(workspace)
-        subprocess.run(
-            ["git", "add", "-A"], cwd=workspace, env=env, capture_output=True
-        )
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=workspace,
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        if result.stdout.strip():
-            subprocess.run(
-                ["git", "commit", "-m", "[ftl-sdlc-loop] Clean up SDLC artifacts"],
-                cwd=workspace,
-                env=env,
-                capture_output=True,
-            )
-            print("Committed artifact cleanup.")
-        else:
-            print("No artifacts to clean.")
-        sys.exit(0)
 
     # Handle --push and --pr early (they exit after completing)
     if "--push" in args or "--pr" in args:
@@ -3323,32 +2778,29 @@ def main():
     # Note: glab needs to run from within a git repo with GitLab remote
     gitlab_issue = None
     if gitlab_issue_number:
-        workspace = get_workspace_dir()
-        if not workspace.exists() or not (workspace / ".git").exists():
-            print(
-                "Error: Workspace must be initialized with --init-from before using --gitlab-issue"
-            )
-            print("  glab requires a git repo with GitLab remote to detect the project")
+        repo = get_repo_root()
+        if not repo.exists() or not (repo / ".git").exists():
+            print("Error: Not a git repository. Use --repo to specify a repo path.")
             sys.exit(1)
         print(f"Fetching GitLab issue #{gitlab_issue_number}...")
-        gitlab_issue = gitlab_fetch_issue(gitlab_issue_number, cwd=workspace)
+        gitlab_issue = gitlab_fetch_issue(gitlab_issue_number, cwd=repo)
         if not gitlab_issue:
             print(f"Error: Could not fetch GitLab issue #{gitlab_issue_number}")
             sys.exit(1)
         print(f"Issue: {gitlab_issue['title']}")
         # Assign to self
-        gitlab_assign_issue(gitlab_issue_number, cwd=workspace)
+        gitlab_assign_issue(gitlab_issue_number, cwd=repo)
         # Generate branch name if not specified
         if not branch_name:
             branch_name = gitlab_branch_name(gitlab_issue)
             print(f"Branch: {branch_name}")
-        # Create feature branch and set as target for agent merges
+        # Create feature branch
         set_target_branch(branch_name)
         env = os.environ.copy()
         env.pop("CLAUDECODE", None)
         subprocess.run(
             ["git", "checkout", "-B", branch_name],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
         )
@@ -3356,15 +2808,13 @@ def main():
     # Handle GitHub issue - fetch and use as task
     github_issue = None
     if github_issue_number:
-        workspace = get_workspace_dir()
-        if not workspace.exists() or not (workspace / ".git").exists():
-            print(
-                "Error: Workspace must be initialized with --init-from before using --github-issue"
-            )
+        repo = get_repo_root()
+        if not repo.exists() or not (repo / ".git").exists():
+            print("Error: Not a git repository. Use --repo to specify a repo path.")
             sys.exit(1)
         print(f"Fetching GitHub issue #{github_issue_number}...")
         github_issue = github_fetch_issue(
-            github_issue_number, repo=github_issue_repo, cwd=workspace
+            github_issue_number, repo=github_issue_repo, cwd=repo
         )
         if not github_issue:
             print(f"Error: Could not fetch GitHub issue #{github_issue_number}")
@@ -3374,13 +2824,13 @@ def main():
         if not branch_name:
             branch_name = github_branch_name(github_issue)
             print(f"Branch: {branch_name}")
-        # Create feature branch and set as target for agent merges
+        # Create feature branch
         set_target_branch(branch_name)
         env = os.environ.copy()
         env.pop("CLAUDECODE", None)
         subprocess.run(
             ["git", "checkout", "-B", branch_name],
-            cwd=workspace,
+            cwd=repo,
             env=env,
             capture_output=True,
         )
@@ -3425,29 +2875,27 @@ def main():
             existing_plan=existing_plan,
         )
 
-        print(f"\nWorkspace: {result['workspace']}")
+        print(f"\nRepo: {result['repo']}")
         if result.get("plan_only"):
             print(
                 "Plan-only mode completed. Review the plan and run with --plan to continue."
             )
         else:
-            print("Run 'git log --oneline' in the workspace to see the commit history.")
+            print("Run 'git log --oneline' to see the commit history.")
 
         # Handle GitLab MR creation
         if gitlab_mr and result.get("final_satisfied"):
             print("\nCreating GitLab merge request...")
-            workspace = get_workspace_dir()
+            repo = get_repo_root()
             env = os.environ.copy()
             env.pop("CLAUDECODE", None)
 
-            # Determine branch name
             mr_branch = branch_name or "ftl-sdlc-work"
 
-            # Only create branch if pipeline ran on main (no feature branch)
             if not branch_name:
                 subprocess.run(
                     ["git", "checkout", "-B", mr_branch],
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
@@ -3455,7 +2903,7 @@ def main():
             # Squash all commits into one clean commit
             sq_result = subprocess.run(
                 ["git", "log", "--oneline", "origin/main..HEAD"],
-                cwd=workspace,
+                cwd=repo,
                 env=env,
                 capture_output=True,
                 text=True,
@@ -3466,7 +2914,7 @@ def main():
                 print(f"Squashing {commit_count} commits...")
                 subprocess.run(
                     ["git", "reset", "--soft", "origin/main"],
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
@@ -3477,20 +2925,7 @@ def main():
                 )
                 subprocess.run(
                     ["git", "commit", "-m", commit_msg],
-                    cwd=workspace,
-                    env=env,
-                    capture_output=True,
-                )
-
-            # Clean artifacts after squash (so they don't end up in the MR)
-            if clean_artifacts:
-                clean_workspace_artifacts(workspace)
-                subprocess.run(
-                    ["git", "add", "-A"], cwd=workspace, env=env, capture_output=True
-                )
-                subprocess.run(
-                    ["git", "commit", "--amend", "--no-edit"],
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
@@ -3499,7 +2934,7 @@ def main():
             print(f"Pushing branch {mr_branch}...")
             push_result = subprocess.run(
                 ["git", "push", "-u", "origin", mr_branch],
-                cwd=workspace,
+                cwd=repo,
                 env=env,
                 capture_output=True,
                 text=True,
@@ -3507,11 +2942,9 @@ def main():
             if push_result.returncode != 0:
                 print(f"Error pushing branch: {push_result.stderr}")
             else:
-                # Create MR
                 mr_title = gitlab_issue["title"] if gitlab_issue else task[:70]
 
-                # Check for MR template in workspace
-                mr_template_path = gitlab_find_mr_template(workspace)
+                mr_template_path = gitlab_find_mr_template(repo)
                 if mr_template_path:
                     print(f"Using MR template: {mr_template_path}")
                     template_content = mr_template_path.read_text()
@@ -3519,10 +2952,9 @@ def main():
                         template_content=template_content,
                         task=task,
                         gitlab_issue=gitlab_issue,
-                        workspace=workspace,
+                        workspace=repo,
                     )
                 else:
-                    # Fallback to simple description
                     mr_description = f"## Description\n\n{task[:500]}\n\n"
                     if gitlab_issue:
                         mr_description += f"Closes #{gitlab_issue['number']}\n\n"
@@ -3534,7 +2966,7 @@ def main():
                     description=mr_description,
                     target_branch="main",
                     assignee=gitlab_get_username(),
-                    cwd=workspace,
+                    cwd=repo,
                 )
                 if mr_url:
                     print(f"Merge request created: {mr_url}")
@@ -3544,17 +2976,16 @@ def main():
         # Handle GitHub PR creation
         if github_pr and result.get("final_satisfied"):
             print("\nCreating GitHub pull request...")
-            workspace = get_workspace_dir()
+            repo = get_repo_root()
             env = os.environ.copy()
             env.pop("CLAUDECODE", None)
 
             pr_branch = branch_name or "ftl-sdlc-work"
 
-            # Only create branch if pipeline ran on main (no feature branch)
             if not branch_name:
                 subprocess.run(
                     ["git", "checkout", "-B", pr_branch],
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
@@ -3562,7 +2993,7 @@ def main():
             # Squash all commits into one clean commit
             sq_result = subprocess.run(
                 ["git", "log", "--oneline", "origin/main..HEAD"],
-                cwd=workspace,
+                cwd=repo,
                 env=env,
                 capture_output=True,
                 text=True,
@@ -3573,7 +3004,7 @@ def main():
                 print(f"Squashing {commit_count} commits...")
                 subprocess.run(
                     ["git", "reset", "--soft", "origin/main"],
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
@@ -3584,40 +3015,24 @@ def main():
                 )
                 subprocess.run(
                     ["git", "commit", "-m", commit_msg],
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                 )
 
-            # Clean artifacts after squash (so they don't end up in the PR)
-            if clean_artifacts:
-                clean_workspace_artifacts(workspace)
-                # Don't use git add -A here — it would re-add the on-disk files
-                # that git rm --cached just removed. The git rm --cached calls
-                # in clean_workspace_artifacts already staged the removals.
-                subprocess.run(
-                    ["git", "commit", "--amend", "--no-edit"],
-                    cwd=workspace,
-                    env=env,
-                    capture_output=True,
-                )
-
-            # Check if there are actual code changes after cleaning artifacts
-            # If the only changes were SDLC artifacts, the diff will be empty
+            # Check if there are actual code changes
             diff_check = subprocess.run(
                 ["git", "diff", "--stat", "origin/main..HEAD"],
-                cwd=workspace, env=env, capture_output=True, text=True
+                cwd=repo, env=env, capture_output=True, text=True
             )
             if not diff_check.stdout.strip():
-                print("No code changes after cleaning artifacts — skipping PR creation.")
-                print("The implementer may have edited files in the source repo instead of the workspace.")
-                print("Check the --init-from source repo for uncommitted changes.")
+                print("No code changes to push — skipping PR creation.")
                 return
 
             print(f"Pushing branch {pr_branch}...")
             push_result = subprocess.run(
                 ["git", "push", "-u", "origin", pr_branch],
-                cwd=workspace,
+                cwd=repo,
                 env=env,
                 capture_output=True,
                 text=True,
@@ -3627,7 +3042,7 @@ def main():
             else:
                 pr_title = github_issue["title"] if github_issue else task[:70]
                 pr_description = github_fill_pr_template(
-                    task=task, github_issue=github_issue, workspace=workspace
+                    task=task, github_issue=github_issue, workspace=repo
                 )
 
                 repo_flag = ["--repo", github_issue_repo] if github_issue_repo else []
@@ -3646,7 +3061,7 @@ def main():
                         pr_branch,
                     ]
                     + repo_flag,
-                    cwd=workspace,
+                    cwd=repo,
                     env=env,
                     capture_output=True,
                     text=True,
@@ -3665,44 +3080,7 @@ def main():
                             pr_url,
                             "--comment",
                         ]
-                        # Use init-from repo for observations (clean tree, no SDLC artifacts)
-                        # Fall back to workspace if init-from not available
-                        review_repo = init_from_path or str(workspace)
-                        if init_from_path:
-                            # Fetch and checkout the PR branch in the source repo
-                            subprocess.run(
-                                ["git", "fetch", "origin", pr_branch],
-                                cwd=init_from_path,
-                                env=env,
-                                capture_output=True,
-                            )
-                            checkout = subprocess.run(
-                                ["git", "checkout", pr_branch],
-                                cwd=init_from_path,
-                                env=env,
-                                capture_output=True,
-                            )
-                            if checkout.returncode != 0:
-                                subprocess.run(
-                                    [
-                                        "git",
-                                        "checkout",
-                                        "-b",
-                                        pr_branch,
-                                        f"origin/{pr_branch}",
-                                    ],
-                                    cwd=init_from_path,
-                                    env=env,
-                                    capture_output=True,
-                                )
-                            else:
-                                subprocess.run(
-                                    ["git", "pull", "--ff-only", "origin", pr_branch],
-                                    cwd=init_from_path,
-                                    env=env,
-                                    capture_output=True,
-                                )
-                        review_cmd.extend(["--repo", review_repo])
+                        review_cmd.extend(["--repo", str(repo)])
                         if github_issue_repo and github_issue_number:
                             issue_ref = f"https://github.com/{github_issue_repo}/issues/{github_issue_number}"
                             review_cmd.extend(["--github-issue", issue_ref])

--- a/src/ftl_sdlc_loop/understand.py
+++ b/src/ftl_sdlc_loop/understand.py
@@ -26,13 +26,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-WORKSPACE = Path(__file__).parent / "workspace"
+from .agent import get_artifacts_dir, get_sdlc_dir
 
 
 def run_claude(prompt: str, continue_session: bool = False) -> str:
     """Run claude -p with the understanding agent context."""
-    # Use the workspace as the context directory for session continuity
-    understand_dir = Path(__file__).parent / "agents" / "understand"
+    understand_dir = get_sdlc_dir() / "agents" / "understand"
     understand_dir.mkdir(parents=True, exist_ok=True)
 
     cmd = ["claude", "-p", prompt]
@@ -55,11 +54,10 @@ def gather_initial_context(task: str, context_sources: list[str] | None = None) 
     if context_sources:
         context_section = "\nADDITIONAL CONTEXT PROVIDED:\n"
         for source in context_sources:
-            # Check if it's a file path
             path = Path(source)
             if path.exists():
                 context_section += f"\n--- {source} ---\n"
-                context_section += path.read_text()[:5000]  # Limit size
+                context_section += path.read_text()[:5000]
                 context_section += "\n"
             else:
                 context_section += f"\n{source}\n"
@@ -206,7 +204,8 @@ Make this document useful for someone starting fresh."""
 def interactive_understanding(task: str, context_sources: list[str] | None = None):
     """Run an interactive shared understanding session."""
 
-    WORKSPACE.mkdir(exist_ok=True)
+    artifacts = get_artifacts_dir()
+    artifacts.mkdir(parents=True, exist_ok=True)
 
     print("=" * 60)
     print("SHARED UNDERSTANDING - Phase 0")
@@ -218,8 +217,7 @@ def interactive_understanding(task: str, context_sources: list[str] | None = Non
     initial_analysis = gather_initial_context(task, context_sources)
     print(f"\n{initial_analysis}\n")
 
-    # Save initial analysis
-    (WORKSPACE / "INITIAL_ANALYSIS.md").write_text(
+    (artifacts / "INITIAL_ANALYSIS.md").write_text(
         f"# Initial Analysis\n\nTask: {task}\n\n{initial_analysis}"
     )
 
@@ -234,7 +232,7 @@ def interactive_understanding(task: str, context_sources: list[str] | None = Non
         try:
             line = input()
             if line == "":
-                if lines:  # Only break if we have some input
+                if lines:
                     break
             else:
                 lines.append(line)
@@ -252,8 +250,7 @@ def interactive_understanding(task: str, context_sources: list[str] | None = Non
     validation = validate_understanding(task, initial_analysis, human_answers)
     print(f"\n{validation}\n")
 
-    # Save validation
-    (WORKSPACE / "VALIDATION.md").write_text(
+    (artifacts / "VALIDATION.md").write_text(
         f"# Validation\n\nHuman Answers:\n{human_answers}\n\n{validation}"
     )
 
@@ -262,15 +259,14 @@ def interactive_understanding(task: str, context_sources: list[str] | None = Non
     shared_doc = create_shared_understanding_doc(task, initial_analysis, validation)
     print(f"\n{shared_doc}\n")
 
-    # Save final document
-    doc_path = WORKSPACE / "SHARED_UNDERSTANDING.md"
+    doc_path = artifacts / "SHARED_UNDERSTANDING.md"
     doc_path.write_text(shared_doc)
 
     print("=" * 60)
     print(f"Shared understanding saved to: {doc_path}")
     print("=" * 60)
     print("\nNext: Run the development loop with this understanding:")
-    print(f'  uv run supervisor.py --understanding {doc_path} "{task}"')
+    print(f'  ftl-sdlc-loop --understanding {doc_path} "{task}"')
 
     return shared_doc
 
@@ -280,7 +276,8 @@ def batch_understanding(
 ):
     """Run shared understanding in batch mode with pre-provided answers."""
 
-    WORKSPACE.mkdir(exist_ok=True)
+    artifacts = get_artifacts_dir()
+    artifacts.mkdir(parents=True, exist_ok=True)
 
     answers = Path(answers_file).read_text()
 
@@ -289,21 +286,18 @@ def batch_understanding(
     print("=" * 60)
     print(f"\nTASK: {task}\n")
 
-    # Step 1: Initial analysis
     print("\n[1/3] Gathering initial context and analyzing task...")
     initial_analysis = gather_initial_context(task, context_sources)
     print(f"\n{initial_analysis}\n")
 
-    # Step 2: Validate with provided answers
     print("\n[2/3] Validating understanding with provided answers...")
     validation = validate_understanding(task, initial_analysis, answers)
     print(f"\n{validation}\n")
 
-    # Step 3: Create final document
     print("\n[3/3] Creating shared understanding document...")
     shared_doc = create_shared_understanding_doc(task, initial_analysis, validation)
 
-    doc_path = WORKSPACE / "SHARED_UNDERSTANDING.md"
+    doc_path = artifacts / "SHARED_UNDERSTANDING.md"
     doc_path.write_text(shared_doc)
 
     print(f"\nSaved to: {doc_path}")
@@ -324,7 +318,6 @@ if __name__ == "__main__":
 
     args = sys.argv[1:]
 
-    # Parse arguments
     context_sources = []
     answers_file = None
     task_parts = []

--- a/tests/test_commit_agent_work.py
+++ b/tests/test_commit_agent_work.py
@@ -1,8 +1,9 @@
 """Tests for commit_agent_work staging behavior.
 
 Uses real git repos in temp directories to verify that source-modifying agents
-(implementer, tester) commit source file changes, while non-source-modifying
-agents (planner, reviewer) only commit files in their own subdirectory.
+(implementer, tester) commit source file changes while excluding .sdlc-loop/,
+and non-source-modifying agents (planner, reviewer) produce no commits since
+their outputs go to gitignored .sdlc-loop/artifacts/.
 """
 
 import subprocess
@@ -27,121 +28,119 @@ def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
     )
 
 
-def _init_workspace(tmp_path: Path) -> Path:
-    """Create a git repo with an initial commit and agent subdirectories."""
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    _git(["init"], workspace)
-    _git(["config", "user.email", "test@test"], workspace)
-    _git(["config", "user.name", "test"], workspace)
-    (workspace / "src").mkdir()
-    (workspace / "src" / "main.py").write_text("print('hello')\n")
-    for role in ("planner", "implementer", "reviewer", "tester", "user"):
-        (workspace / role).mkdir()
-    _git(["add", "-A"], workspace)
-    _git(["commit", "-m", "initial"], workspace)
-    # Create a branch for the agent to work on
-    _git(["checkout", "-b", "implementer"], workspace)
-    _git(["checkout", "-b", "tester"], workspace)
-    _git(["checkout", "-b", "planner"], workspace)
-    _git(["checkout", "main"], workspace)
-    return workspace
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a git repo with source code and .sdlc-loop/ gitignored."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init"], repo)
+    _git(["config", "user.email", "test@test"], repo)
+    _git(["config", "user.name", "test"], repo)
+    (repo / "src").mkdir()
+    (repo / "src" / "main.py").write_text("print('hello')\n")
+    (repo / ".gitignore").write_text(".sdlc-loop/\n")
+    # Create .sdlc-loop structure
+    sdlc = repo / ".sdlc-loop"
+    (sdlc / "artifacts" / "planner").mkdir(parents=True)
+    (sdlc / "artifacts" / "implementer").mkdir(parents=True)
+    (sdlc / "artifacts" / "reviewer").mkdir(parents=True)
+    _git(["add", "-A"], repo)
+    _git(["commit", "-m", "initial"], repo)
+    return repo
 
 
-def _committed_files(workspace: Path) -> list[str]:
+def _committed_files(repo: Path) -> list[str]:
     """Return list of files changed in the last commit."""
-    result = _git(["diff", "--name-only", "HEAD~1", "HEAD"], workspace)
+    result = _git(["diff", "--name-only", "HEAD~1", "HEAD"], repo)
     return sorted(result.stdout.strip().split("\n")) if result.stdout.strip() else []
 
 
 def test_implementer_commits_source_files(tmp_path):
-    """Implementer should commit both its subdirectory files and source files."""
-    workspace = _init_workspace(tmp_path)
-    _git(["checkout", "implementer"], workspace)
+    """Implementer should commit source file changes."""
+    repo = _init_repo(tmp_path)
 
-    # Simulate implementer editing a source file and writing to its own dir
-    (workspace / "src" / "main.py").write_text("print('modified')\n")
-    (workspace / "implementer" / "notes.md").write_text("implementation notes\n")
+    (repo / "src" / "main.py").write_text("print('modified')\n")
 
-    with patch("ftl_sdlc_loop.agent.get_workspace_dir", return_value=workspace):
+    with patch("ftl_sdlc_loop.agent.get_repo_root", return_value=repo):
         from ftl_sdlc_loop.agent import commit_agent_work
 
         result = commit_agent_work("implementer", "test commit")
 
     assert result is True
-    files = _committed_files(workspace)
+    files = _committed_files(repo)
     assert "src/main.py" in files
-    assert "implementer/notes.md" in files
 
 
-def test_implementer_excludes_other_agent_dirs(tmp_path):
-    """Implementer should not stage files in other agents' subdirectories."""
-    workspace = _init_workspace(tmp_path)
-    _git(["checkout", "implementer"], workspace)
+def test_implementer_excludes_sdlc_loop(tmp_path):
+    """Implementer should not commit files under .sdlc-loop/."""
+    repo = _init_repo(tmp_path)
 
-    # Simulate another agent leaving uncommitted work
-    (workspace / "reviewer" / "REVIEW.md").write_text("review notes\n")
-    (workspace / "planner" / "PLAN.md").write_text("plan notes\n")
-    # Implementer edits source
-    (workspace / "src" / "main.py").write_text("print('modified')\n")
+    (repo / "src" / "main.py").write_text("print('modified')\n")
+    (repo / ".sdlc-loop" / "artifacts" / "implementer" / "notes.md").write_text("notes\n")
 
-    with patch("ftl_sdlc_loop.agent.get_workspace_dir", return_value=workspace):
+    with patch("ftl_sdlc_loop.agent.get_repo_root", return_value=repo):
         from ftl_sdlc_loop.agent import commit_agent_work
 
         result = commit_agent_work("implementer", "test commit")
 
     assert result is True
-    files = _committed_files(workspace)
+    files = _committed_files(repo)
     assert "src/main.py" in files
-    assert "reviewer/REVIEW.md" not in files
-    assert "planner/PLAN.md" not in files
+    for f in files:
+        assert not f.startswith(".sdlc-loop/")
 
 
 def test_tester_commits_source_files(tmp_path):
-    """Tester should commit both its subdirectory files and source files."""
-    workspace = _init_workspace(tmp_path)
-    _git(["checkout", "tester"], workspace)
+    """Tester should commit source and test file changes."""
+    repo = _init_repo(tmp_path)
+    (repo / "tests").mkdir(exist_ok=True)
 
-    (workspace / "src" / "main.py").write_text("print('tested')\n")
-    (workspace / "tester" / "report.md").write_text("test report\n")
+    (repo / "src" / "main.py").write_text("print('tested')\n")
+    (repo / "tests" / "test_main.py").write_text("def test_it(): pass\n")
 
-    with patch("ftl_sdlc_loop.agent.get_workspace_dir", return_value=workspace):
+    with patch("ftl_sdlc_loop.agent.get_repo_root", return_value=repo):
         from ftl_sdlc_loop.agent import commit_agent_work
 
         result = commit_agent_work("tester", "test commit")
 
     assert result is True
-    files = _committed_files(workspace)
+    files = _committed_files(repo)
     assert "src/main.py" in files
-    assert "tester/report.md" in files
+    assert "tests/test_main.py" in files
 
 
-def test_planner_only_commits_own_directory(tmp_path):
-    """Planner should only commit files in planner/, not source files."""
-    workspace = _init_workspace(tmp_path)
-    _git(["checkout", "planner"], workspace)
+def test_planner_returns_false(tmp_path):
+    """Planner is not a source-modifying role — commit_agent_work returns False."""
+    repo = _init_repo(tmp_path)
 
-    # Planner writes to its directory; a source file is also modified (shouldn't be staged)
-    (workspace / "planner" / "PLAN.md").write_text("the plan\n")
-    (workspace / "src" / "main.py").write_text("print('should not be committed')\n")
+    (repo / ".sdlc-loop" / "artifacts" / "planner" / "PLAN.md").write_text("the plan\n")
 
-    with patch("ftl_sdlc_loop.agent.get_workspace_dir", return_value=workspace):
+    with patch("ftl_sdlc_loop.agent.get_repo_root", return_value=repo):
         from ftl_sdlc_loop.agent import commit_agent_work
 
         result = commit_agent_work("planner", "test commit")
 
-    assert result is True
-    files = _committed_files(workspace)
-    assert "planner/PLAN.md" in files
-    assert "src/main.py" not in files
+    assert result is False
+
+
+def test_reviewer_returns_false(tmp_path):
+    """Reviewer is not a source-modifying role — commit_agent_work returns False."""
+    repo = _init_repo(tmp_path)
+
+    (repo / ".sdlc-loop" / "artifacts" / "reviewer" / "REVIEW.md").write_text("review\n")
+
+    with patch("ftl_sdlc_loop.agent.get_repo_root", return_value=repo):
+        from ftl_sdlc_loop.agent import commit_agent_work
+
+        result = commit_agent_work("reviewer", "test commit")
+
+    assert result is False
 
 
 def test_no_changes_returns_false(tmp_path):
-    """commit_agent_work should return False when there are no changes."""
-    workspace = _init_workspace(tmp_path)
-    _git(["checkout", "implementer"], workspace)
+    """commit_agent_work should return False when there are no source changes."""
+    repo = _init_repo(tmp_path)
 
-    with patch("ftl_sdlc_loop.agent.get_workspace_dir", return_value=workspace):
+    with patch("ftl_sdlc_loop.agent.get_repo_root", return_value=repo):
         from ftl_sdlc_loop.agent import commit_agent_work
 
         result = commit_agent_work("implementer", "nothing to commit")


### PR DESCRIPTION
## Summary

- Agents now work directly in the target code repo instead of a cloned workspace
- All SDLC state (plans, reviews, sessions, beliefs) lives under `.sdlc-loop/` which is gitignored
- Eliminates LLM agent confusion about which repo they're operating in
- Non-code artifacts no longer pollute the code repo's git history
- Removes per-agent branches, workspace cloning, artifact cleanup — net -796 lines

## Changes

- **agent.py**: New path model (`get_repo_root()`, `get_sdlc_dir()`, `get_artifacts_dir()`). Removed `init_workspace`, `setup_agent_branch`, `merge_to_main`, `finalize_agent`. Simplified `commit_agent_work` to only handle source-modifying roles.
- **supervisor.py**: Added `init_sdlc_dir()`. Removed `init_workspace_from`, `clean_workspace_artifacts`, `ARTIFACT_PATTERNS`. Replaced `--init-from` with `--repo PATH`. Simplified `push_workspace`.
- **understand.py**: Uses `.sdlc-loop/` paths instead of hardcoded module-relative workspace.
- **tests**: Updated for new path model and `.sdlc-loop/` exclusion semantics.
- **docs**: Updated CLAUDE.md and workspace-architecture.md.

## Test plan

- [x] All 23 existing tests pass
- [ ] Run `ftl-sdlc-loop --repo /tmp/test-repo --task "hello world" --effort minimal`
- [ ] Verify `.sdlc-loop/` created and gitignored
- [ ] Verify no SDLC artifacts in `git log`
- [ ] Verify `--push` works from real repo

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)