### PR TITLE
Replace beliefs_lib with reasons CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "ftl-beliefs",
+    "ftl-reasons",
 ]
 
 [project.urls]

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -20,72 +20,26 @@ All SDLC artifacts are stored under .sdlc-loop/ which is gitignored.
 import os
 import subprocess
 import sys
-from datetime import datetime
 from pathlib import Path
 
-# Repo root — the actual code repository agents work in
-_repo_root: Path | None = None
-
-
-def set_repo_root(path: Path) -> None:
-    """Set the target code repo root."""
-    global _repo_root
-    _repo_root = path
-
-
-def get_repo_root() -> Path:
-    """Get the target code repo root. Defaults to CWD."""
-    return _repo_root or Path.cwd()
-
-
-def get_sdlc_dir() -> Path:
-    """Get the .sdlc-loop directory for SDLC state."""
-    return get_repo_root() / ".sdlc-loop"
-
-
-def get_artifacts_dir() -> Path:
-    """Get the artifacts directory for SDLC documents."""
-    return get_sdlc_dir() / "artifacts"
-
-
-
-def get_agents_dir() -> Path:
-    """Get the agents session directory under .sdlc-loop/."""
-    return get_sdlc_dir() / "agents"
-
-
-# Target branch for commits (default: main)
-_target_branch = "main"
-
-# Additional read-only context directories (set via --context-dir)
-_context_dirs: list[str] = []
-
-
-def set_target_branch(branch: str) -> None:
-    """Set the target branch for work."""
-    global _target_branch
-    _target_branch = branch
-
-
-def get_target_branch() -> str:
-    """Get the target branch."""
-    return _target_branch
-
-
-def set_context_dirs(dirs: list[str]) -> None:
-    """Set additional read-only context directories for agents."""
-    global _context_dirs
-    _context_dirs = dirs
-
-
-def get_context_dirs() -> list[str]:
-    """Get additional read-only context directories."""
-    return _context_dirs
+from .config import (
+    get_agents_dir,
+    get_artifacts_dir,
+    get_context_dirs,
+    get_repo_root,
+    get_sdlc_dir,
+    log,
+    log_separator,
+    set_context_dirs,
+    set_repo_root,
+    set_target_branch,
+    get_target_branch,
+)
+from .reasons import get_reasons_db
 
 
 def get_reasons_instructions() -> str:
     """Return prompt section with read-only reasons CLI commands."""
-    from .reasons import get_reasons_db
     db = get_reasons_db()
     if not db.exists():
         return ""
@@ -109,34 +63,6 @@ Available commands (via Bash):
 Do NOT use: add, retract, assert, init, or any write commands.
 The supervisor manages belief registration.
 """
-
-
-# Logging
-VERBOSE = True
-_log_file_handle = None
-
-
-def _get_log_file():
-    """Get or create log file handle."""
-    global _log_file_handle
-    if _log_file_handle is None:
-        log_file = get_sdlc_dir() / "multiagent.log"
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-        _log_file_handle = open(log_file, "a")
-    return _log_file_handle
-
-
-def log(msg: str, level: str = "INFO"):
-    """Log a message with timestamp to stderr and file."""
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    log_line = f"[{timestamp}] [{level}] {msg}"
-
-    f = _get_log_file()
-    f.write(log_line + "\n")
-    f.flush()
-
-    if VERBOSE or level in ["ERROR", "WARN"]:
-        print(log_line, file=sys.stderr)
 
 
 # PID file management
@@ -258,15 +184,6 @@ def git_cmd(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["git"] + args, cwd=cwd, env=env, capture_output=True, text=True
     )
-
-
-def log_separator(title: str = "NEW RUN"):
-    """Add a visible separator in the log file."""
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    separator = f"\n{'='*60}\n{title} - {timestamp}\n{'='*60}\n"
-    f = _get_log_file()
-    f.write(separator)
-    f.flush()
 
 
 def setup_agent_workspace(role: str) -> Path:

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -219,22 +219,22 @@ def show_status() -> None:
 # Agent permissions configuration
 AGENT_PERMISSIONS = {
     "understand": {
-        "allowed_tools": ["Read", "Glob", "Grep", "Bash"],
+        "allowed_tools": ["Read", "Glob", "Grep", "Bash(reasons*)"],
         "can_write": False,
         "description": "Can read files for context gathering, query beliefs",
     },
     "planner": {
-        "allowed_tools": ["Read", "Glob", "Grep", "Write", "Bash"],
+        "allowed_tools": ["Read", "Glob", "Grep", "Write", "Bash(reasons*)"],
         "can_write": True,
         "description": "Can read codebase, writes plan, query beliefs",
     },
     "implementer": {
-        "allowed_tools": ["Read", "Write", "Edit", "Glob", "Grep", "Bash"],
+        "allowed_tools": ["Read", "Write", "Edit", "Glob", "Grep", "Bash(reasons*)"],
         "can_write": True,
         "description": "Can read/write/edit files, query beliefs",
     },
     "reviewer": {
-        "allowed_tools": ["Read", "Glob", "Grep", "Write", "Bash"],
+        "allowed_tools": ["Read", "Glob", "Grep", "Write", "Bash(reasons*)"],
         "can_write": True,
         "description": "Can read files for review, writes review, query beliefs",
     },

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -60,9 +60,6 @@ _target_branch = "main"
 # Additional read-only context directories (set via --context-dir)
 _context_dirs: list[str] = []
 
-# Reasons database path for belief queries
-_reasons_db_path: Path | None = None
-
 
 def set_target_branch(branch: str) -> None:
     """Set the target branch for work."""
@@ -86,17 +83,12 @@ def get_context_dirs() -> list[str]:
     return _context_dirs
 
 
-def set_reasons_db(path: Path) -> None:
-    """Set the reasons database path for agent prompt injection."""
-    global _reasons_db_path
-    _reasons_db_path = path
-
-
 def get_reasons_instructions() -> str:
     """Return prompt section with read-only reasons CLI commands."""
-    if _reasons_db_path is None or not _reasons_db_path.exists():
+    from .reasons import get_reasons_db
+    db = get_reasons_db()
+    if not db.exists():
         return ""
-    db = _reasons_db_path
     return f"""
 ## BELIEFS / REASONS SYSTEM
 

--- a/src/ftl_sdlc_loop/agent.py
+++ b/src/ftl_sdlc_loop/agent.py
@@ -60,6 +60,9 @@ _target_branch = "main"
 # Additional read-only context directories (set via --context-dir)
 _context_dirs: list[str] = []
 
+# Reasons database path for belief queries
+_reasons_db_path: Path | None = None
+
 
 def set_target_branch(branch: str) -> None:
     """Set the target branch for work."""
@@ -81,6 +84,39 @@ def set_context_dirs(dirs: list[str]) -> None:
 def get_context_dirs() -> list[str]:
     """Get additional read-only context directories."""
     return _context_dirs
+
+
+def set_reasons_db(path: Path) -> None:
+    """Set the reasons database path for agent prompt injection."""
+    global _reasons_db_path
+    _reasons_db_path = path
+
+
+def get_reasons_instructions() -> str:
+    """Return prompt section with read-only reasons CLI commands."""
+    if _reasons_db_path is None or not _reasons_db_path.exists():
+        return ""
+    db = _reasons_db_path
+    return f"""
+## BELIEFS / REASONS SYSTEM
+
+You have access to a belief tracking database via the `reasons` CLI.
+Use it to query what is known, what warnings exist, and what decisions were made.
+
+Database path: {db}
+
+Available commands (via Bash):
+  reasons --db {db} search "query"        # Search beliefs by keyword
+  reasons --db {db} compact --budget 500  # Summarize current belief state
+  reasons --db {db} list --status IN      # List all active beliefs
+  reasons --db {db} list-gated            # Find beliefs blocked by active problems
+  reasons --db {db} explain NODE_ID       # Explain why a belief is IN or OUT
+  reasons --db {db} show NODE_ID          # Show full details of a belief
+  reasons --db {db} ask "question"        # Ask a question about beliefs
+
+Do NOT use: add, retract, assert, init, or any write commands.
+The supervisor manages belief registration.
+"""
 
 
 # Logging
@@ -191,24 +227,24 @@ def show_status() -> None:
 # Agent permissions configuration
 AGENT_PERMISSIONS = {
     "understand": {
-        "allowed_tools": ["Read", "Glob", "Grep"],
+        "allowed_tools": ["Read", "Glob", "Grep", "Bash"],
         "can_write": False,
-        "description": "Can read files for context gathering",
+        "description": "Can read files for context gathering, query beliefs",
     },
     "planner": {
-        "allowed_tools": ["Read", "Glob", "Grep", "Write"],
+        "allowed_tools": ["Read", "Glob", "Grep", "Write", "Bash"],
         "can_write": True,
-        "description": "Can read codebase, writes plan to their directory",
+        "description": "Can read codebase, writes plan, query beliefs",
     },
     "implementer": {
-        "allowed_tools": ["Read", "Write", "Edit", "Glob", "Grep"],
+        "allowed_tools": ["Read", "Write", "Edit", "Glob", "Grep", "Bash"],
         "can_write": True,
-        "description": "Can read/write/edit files in the project",
+        "description": "Can read/write/edit files, query beliefs",
     },
     "reviewer": {
-        "allowed_tools": ["Read", "Glob", "Grep", "Write"],
+        "allowed_tools": ["Read", "Glob", "Grep", "Write", "Bash"],
         "can_write": True,
-        "description": "Can read files for review, writes review to their directory",
+        "description": "Can read files for review, writes review, query beliefs",
     },
     "tester": {
         "allowed_tools": ["Read", "Write", "Edit", "Glob", "Grep", "Bash"],
@@ -372,11 +408,13 @@ The following files are available from previous stages:
 {message}
 """
 
+    reasons_section = get_reasons_instructions()
+
     full_prompt += f"""
 You are working directly in the project at: {repo}
 Write any SDLC output files (plans, reviews, reports) to: {agent_artifact_dir}
 Your working directory is {agent_cwd}.
-{ref_dirs_section}"""
+{ref_dirs_section}{reasons_section}"""
 
     cmd = ["claude", "-p", full_prompt]
 

--- a/src/ftl_sdlc_loop/config.py
+++ b/src/ftl_sdlc_loop/config.py
@@ -1,0 +1,103 @@
+"""Shared path configuration and logging for the SDLC loop.
+
+Both agent.py and reasons.py import from here, avoiding circular dependencies.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Repo root — the actual code repository agents work in
+_repo_root: Path | None = None
+
+
+def set_repo_root(path: Path) -> None:
+    """Set the target code repo root."""
+    global _repo_root
+    _repo_root = path
+
+
+def get_repo_root() -> Path:
+    """Get the target code repo root. Defaults to CWD."""
+    return _repo_root or Path.cwd()
+
+
+def get_sdlc_dir() -> Path:
+    """Get the .sdlc-loop directory for SDLC state."""
+    return get_repo_root() / ".sdlc-loop"
+
+
+def get_artifacts_dir() -> Path:
+    """Get the artifacts directory for SDLC documents."""
+    return get_sdlc_dir() / "artifacts"
+
+
+def get_agents_dir() -> Path:
+    """Get the agents session directory under .sdlc-loop/."""
+    return get_sdlc_dir() / "agents"
+
+
+# Target branch for commits (default: main)
+_target_branch = "main"
+
+# Additional read-only context directories (set via --context-dir)
+_context_dirs: list[str] = []
+
+
+def set_target_branch(branch: str) -> None:
+    """Set the target branch for work."""
+    global _target_branch
+    _target_branch = branch
+
+
+def get_target_branch() -> str:
+    """Get the target branch."""
+    return _target_branch
+
+
+def set_context_dirs(dirs: list[str]) -> None:
+    """Set additional read-only context directories for agents."""
+    global _context_dirs
+    _context_dirs = dirs
+
+
+def get_context_dirs() -> list[str]:
+    """Get additional read-only context directories."""
+    return _context_dirs
+
+
+# Logging
+VERBOSE = True
+_log_file_handle = None
+
+
+def _get_log_file():
+    """Get or create log file handle."""
+    global _log_file_handle
+    if _log_file_handle is None:
+        log_file = get_sdlc_dir() / "multiagent.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        _log_file_handle = open(log_file, "a")
+    return _log_file_handle
+
+
+def log(msg: str, level: str = "INFO"):
+    """Log a message with timestamp to stderr and file."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    log_line = f"[{timestamp}] [{level}] {msg}"
+
+    f = _get_log_file()
+    f.write(log_line + "\n")
+    f.flush()
+
+    if VERBOSE or level in ["ERROR", "WARN"]:
+        print(log_line, file=sys.stderr)
+
+
+def log_separator(title: str = "NEW RUN"):
+    """Add a visible separator in the log file."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    separator = f"\n{'='*60}\n{title} - {timestamp}\n{'='*60}\n"
+    f = _get_log_file()
+    f.write(separator)
+    f.flush()

--- a/src/ftl_sdlc_loop/reasons.py
+++ b/src/ftl_sdlc_loop/reasons.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .agent import get_sdlc_dir, log
+from .config import get_sdlc_dir, log
 
 _reasons_db: Path | None = None
 

--- a/src/ftl_sdlc_loop/reasons.py
+++ b/src/ftl_sdlc_loop/reasons.py
@@ -83,11 +83,9 @@ def reasons_compact(budget: int = 500) -> str | None:
 
 
 def reasons_list_warnings() -> str | None:
-    result = _run_reasons("list", "--status", "IN")
-    if result.returncode != 0 or not result.stdout.strip():
-        return None
-    lines = [line for line in result.stdout.strip().split("\n") if "warn" in line.lower()]
-    return "\n".join(lines) if lines else None
+    result = _run_reasons("list", "--status", "IN", "--label", "WARNING")
+    output = result.stdout.strip()
+    return output if output else None
 
 
 def reasons_check_stale() -> None:

--- a/src/ftl_sdlc_loop/reasons.py
+++ b/src/ftl_sdlc_loop/reasons.py
@@ -1,0 +1,116 @@
+"""Wrapper for the `reasons` CLI tool.
+
+The supervisor calls these functions to register and query beliefs.
+Agents get read-only CLI access via prompt instructions (see agent.py).
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from .agent import get_sdlc_dir, log
+
+_reasons_db: Path | None = None
+
+
+def set_reasons_db(path: Path) -> None:
+    global _reasons_db
+    _reasons_db = path
+
+
+def get_reasons_db() -> Path:
+    return _reasons_db or get_sdlc_dir() / "reasons.db"
+
+
+def _find_reasons_bin() -> str:
+    found = shutil.which("reasons")
+    if found:
+        return found
+    home = Path.home() / ".local" / "bin" / "reasons"
+    if home.exists():
+        return str(home)
+    return "reasons"
+
+
+def _run_reasons(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    db = str(get_reasons_db())
+    cmd = [_find_reasons_bin(), "--db", db] + list(args)
+    env = os.environ.copy()
+    env.pop("CLAUDECODE", None)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=60)
+        if result.returncode != 0 and result.stderr:
+            log(f"reasons {' '.join(args)}: {result.stderr.strip()}", "WARN")
+        if check and result.returncode != 0:
+            log(f"reasons command failed: {' '.join(args)}", "ERROR")
+        return result
+    except FileNotFoundError:
+        log("reasons CLI not found — install ftl-reasons", "ERROR")
+        return subprocess.CompletedProcess(cmd, 1, "", "reasons: command not found")
+    except subprocess.TimeoutExpired:
+        log(f"reasons {' '.join(args)}: timed out", "ERROR")
+        return subprocess.CompletedProcess(cmd, 1, "", "timeout")
+
+
+def reasons_init() -> None:
+    db = get_reasons_db()
+    if db.exists():
+        return
+    db.parent.mkdir(parents=True, exist_ok=True)
+    _run_reasons("init")
+
+
+def reasons_add(
+    node_id: str,
+    text: str,
+    label: str = "DERIVED",
+    depends_on: list[str] | None = None,
+    source: str | None = None,
+) -> None:
+    args = ["add", node_id, text, "--label", label]
+    if depends_on:
+        args.extend(["--sl", ",".join(depends_on)])
+    if source:
+        args.extend(["--source", source])
+    _run_reasons(*args)
+
+
+def reasons_compact(budget: int = 500) -> str | None:
+    result = _run_reasons("compact", "--budget", str(budget))
+    output = result.stdout.strip()
+    return output if output else None
+
+
+def reasons_list_warnings() -> str | None:
+    result = _run_reasons("list", "--status", "IN")
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    lines = [line for line in result.stdout.strip().split("\n") if "warn" in line.lower()]
+    return "\n".join(lines) if lines else None
+
+
+def reasons_check_stale() -> None:
+    result = _run_reasons("check-stale")
+    if result.stdout.strip():
+        for line in result.stdout.strip().split("\n"):
+            print(f"  [reasons] {line}")
+
+
+def reasons_search(query: str) -> str | None:
+    result = _run_reasons("search", query)
+    output = result.stdout.strip()
+    return output if output else None
+
+
+def reasons_list_gated() -> str | None:
+    result = _run_reasons("list-gated")
+    output = result.stdout.strip()
+    return output if output else None
+
+
+def reasons_retract(node_id: str, reason: str | None = None) -> None:
+    args = ["retract", node_id]
+    if reason:
+        args.extend(["--reason", reason])
+    _run_reasons(*args)

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -1776,8 +1776,8 @@ def run_iteration(
             )
 
     # Stage 5: User feedback (skip if effort level is minimal or moderate)
-    # Initialize beliefs_warnings before the if/else to avoid UnboundLocalError
-    beliefs_warnings = None
+    # Initialize reasons_warnings before the if/else to avoid UnboundLocalError
+    reasons_warnings = None
 
     if skip_user:
         print("\n[5/5] USER skipped (effort level does not include user testing)")
@@ -1806,7 +1806,7 @@ def run_iteration(
             usage_for_user += f"\n\nBELIEFS STATE:\n{reasons_summary}"
 
         # Check for active warnings from reasons
-        beliefs_warnings = reasons_list_warnings()
+        reasons_warnings = reasons_list_warnings()
 
         user_result = user(
             results["implementer"],
@@ -1839,7 +1839,7 @@ def run_iteration(
             results["user_satisfied"] = False
 
     # Exit gate: SATISFIED + active beliefs WARNINGs
-    if results["user_satisfied"] and beliefs_warnings:
+    if results["user_satisfied"] and reasons_warnings:
         print(
             "  [EXIT GATE] User SATISFIED but beliefs system has active WARNINGs — escalating to human"
         )
@@ -1847,7 +1847,7 @@ def run_iteration(
             "user",
             {
                 "needs_human": True,
-                "message": f"User declared SATISFIED but beliefs system has active WARNINGs:\n{beliefs_warnings}\n\nAccept or reject?",
+                "message": f"User declared SATISFIED but beliefs system has active WARNINGs:\n{reasons_warnings}\n\nAccept or reject?",
             },
             iteration,
             no_questions,

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -34,18 +34,18 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-from .agent import (
+from .config import (
     get_artifacts_dir,
     get_repo_root,
     get_sdlc_dir,
     get_target_branch,
     log,
     log_separator,
-    run_agent,
     set_context_dirs,
     set_repo_root,
     set_target_branch,
 )
+from .agent import run_agent
 
 # Queue file handling for continuous mode
 DEFAULT_QUEUE_PATH = Path("queue.txt")

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -2582,6 +2582,8 @@ def main():
         reasons_db_path = os.path.expanduser(args[idx + 1])
         if not os.path.isfile(reasons_db_path):
             print(f"Error: Reasons database not found: {reasons_db_path}")
+            print("  --reasons-db expects a pre-built database (e.g. from code-expert).")
+            print("  Omit this flag to auto-create a new database at .sdlc-loop/reasons.db.")
             sys.exit(1)
         args = args[:idx] + args[idx + 2 :]
 

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -2096,10 +2096,6 @@ def run_pipeline(
     # Initialize reasons database
     reasons_init()
 
-    # Set reasons DB path for agent prompt injection
-    from .agent import set_reasons_db as set_agent_reasons_db
-    set_agent_reasons_db(get_reasons_db())
-
     # Load shared understanding if provided
     shared_understanding = None
     if understanding_path:

--- a/src/ftl_sdlc_loop/supervisor.py
+++ b/src/ftl_sdlc_loop/supervisor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["beliefs @ git+https://github.com/benthomasson/beliefs.git"]
+# dependencies = ["ftl-reasons"]
 # ///
 
 """
@@ -993,86 +993,16 @@ def save_entry(
     return path
 
 
-from beliefs_lib import Claim
-from beliefs_lib.check_refs import check_refs as _beliefs_check_refs
-from beliefs_lib.compact import compact as _beliefs_compact
-from beliefs_lib.parser import append_claim, parse_nogoods, parse_registry
-
-
-def _beliefs_registry_path() -> Path:
-    return get_sdlc_dir() / "beliefs.md"
-
-
-def _beliefs_nogoods_path() -> Path:
-    return get_sdlc_dir() / "nogoods.md"
-
-
-def beliefs_init():
-    """Initialize beliefs.md and nogoods.md under .sdlc-loop/ if they don't exist."""
-    registry = _beliefs_registry_path()
-    nogoods = _beliefs_nogoods_path()
-    registry.parent.mkdir(parents=True, exist_ok=True)
-    if not registry.exists():
-        registry.write_text("# Beliefs Registry\n\n## Repos\n\n")
-    if not nogoods.exists():
-        nogoods.write_text("# Nogoods\n\n")
-
-
-def beliefs_add(
-    claim_id: str, text: str, claim_type: str = "DERIVED", depends_on: str | None = None
-):
-    """Register a claim in the beliefs system."""
-    registry = _beliefs_registry_path()
-    if not registry.exists():
-        return
-    claim = Claim(
-        id=claim_id,
-        text=text,
-        type=claim_type,
-        status="IN",
-        date=datetime.now().strftime("%Y-%m-%d"),
-        depends_on=[depends_on] if depends_on else [],
-    )
-    append_claim(registry, claim)
-
-
-def beliefs_compact(budget: int = 500) -> str | None:
-    """Return a compact summary of current beliefs."""
-    registry = _beliefs_registry_path()
-    if not registry.exists():
-        return None
-    repos, claims = parse_registry(registry)
-    nogoods = (
-        parse_nogoods(_beliefs_nogoods_path())
-        if _beliefs_nogoods_path().exists()
-        else []
-    )
-    result = _beliefs_compact(claims, nogoods, budget=budget)
-    return result if result.strip() else None
-
-
-def beliefs_check_refs():
-    """Check cross-references for all claims."""
-    registry = _beliefs_registry_path()
-    if not registry.exists():
-        return
-    repos, claims = parse_registry(registry)
-    results = _beliefs_check_refs(claims, repos)
-    for claim_id, status, message in results:
-        if status != "OK":
-            print(f"  [beliefs] {claim_id}: {status} — {message}")
-
-
-def beliefs_list_warnings() -> str | None:
-    """List active WARNING claims."""
-    registry = _beliefs_registry_path()
-    if not registry.exists():
-        return None
-    repos, claims = parse_registry(registry)
-    warnings = [c for c in claims if c.type == "WARNING" and c.status == "IN"]
-    if not warnings:
-        return None
-    return "\n".join(f"- [{c.id}] {c.text}" for c in warnings)
+from .reasons import (
+    get_reasons_db,
+    reasons_add,
+    reasons_check_stale,
+    reasons_compact,
+    reasons_init,
+    reasons_list_gated,
+    reasons_list_warnings,
+    set_reasons_db,
+)
 
 
 def planner(
@@ -1638,15 +1568,15 @@ def run_iteration(
         save_entry(iteration, "planner", results["planner"])
         print(f"\n{results['planner']}\n")
 
-    # Beliefs: register planner decisions as AXIOMs
-    if _beliefs_registry_path().exists():
+    # Reasons: register planner decisions as AXIOMs
+    if get_reasons_db().exists():
         import re
 
         numbered_items = re.findall(
             r"^\d+\.\s+(.+)$", plan_result.get("output", ""), re.MULTILINE
         )
-        for i, item in enumerate(numbered_items[:5]):  # cap at 5
-            beliefs_add(f"plan-{iteration}-{i+1}", item[:200], "AXIOM")
+        for i, item in enumerate(numbered_items[:5]):
+            reasons_add(f"plan-{iteration}-{i+1}", item[:200], label="AXIOM")
 
     # Stage 2 & 3: Implementation + Review loop
     reviewer_feedback = None
@@ -1683,10 +1613,10 @@ def run_iteration(
         )
         print(f"\n{results['implementer']}\n")
 
-        # Beliefs: register implemented files as DERIVED claims
-        if _beliefs_registry_path().exists():
+        # Reasons: register implemented files as DERIVED claims
+        if get_reasons_db().exists():
             for f in results["files_created"]:
-                beliefs_add(f"impl-{iteration}-{f}", f"Created {f}", "DERIVED")
+                reasons_add(f"impl-{iteration}-{f}", f"Created {f}", label="DERIVED", source=f)
 
         # Review (skip if effort level is minimal)
         if skip_review:
@@ -1722,17 +1652,17 @@ def run_iteration(
             )
             print(f"\n{results['reviewer']}\n")
 
-        # Beliefs: register reviewer issues as WARNINGs
-        if _beliefs_registry_path().exists():
+        # Reasons: register reviewer issues as WARNINGs
+        if get_reasons_db().exists():
             for i, issue in enumerate(
                 review_result.get("verdict", {}).get("open_issues", [])
             ):
-                beliefs_add(
+                reasons_add(
                     f"review-warn-{iteration}-{inner_iteration}-{i+1}",
                     issue[:200],
-                    "WARNING",
+                    label="WARNING",
                 )
-            beliefs_check_refs()
+            reasons_check_stale()
 
         if review_result["approved"]:
             print("  [Reviewer APPROVED - proceeding to tester]")
@@ -1814,19 +1744,19 @@ def run_iteration(
         )
         print(f"\n{results['tester']}\n")
 
-        # Beliefs: register test results as OBSERVATIONs
-        if _beliefs_registry_path().exists():
+        # Reasons: register test results as OBSERVATIONs
+        if get_reasons_db().exists():
             status = test_result.get("verdict", {}).get("status", "UNKNOWN")
-            beliefs_add(
-                f"test-{iteration}-{tester_iteration}", f"Tests {status}", "OBSERVATION"
+            reasons_add(
+                f"test-{iteration}-{tester_iteration}", f"Tests {status}", label="OBSERVATION"
             )
             for i, issue in enumerate(
                 test_result.get("verdict", {}).get("open_issues", [])
             ):
-                beliefs_add(
+                reasons_add(
                     f"test-warn-{iteration}-{tester_iteration}-{i+1}",
                     issue[:200],
-                    "WARNING",
+                    label="WARNING",
                 )
 
         if results["tests_passed"]:
@@ -1870,13 +1800,13 @@ def run_iteration(
                 f"- {issue}" for issue in results["unresolved_issues"]
             )
 
-        # Inject beliefs compact summary if available
-        beliefs_summary = beliefs_compact(500)
-        if beliefs_summary:
-            usage_for_user += f"\n\nBELIEFS STATE:\n{beliefs_summary}"
+        # Inject reasons compact summary if available
+        reasons_summary = reasons_compact(500)
+        if reasons_summary:
+            usage_for_user += f"\n\nBELIEFS STATE:\n{reasons_summary}"
 
-        # Check for active warnings from beliefs
-        beliefs_warnings = beliefs_list_warnings()
+        # Check for active warnings from reasons
+        beliefs_warnings = reasons_list_warnings()
 
         user_result = user(
             results["implementer"],
@@ -2163,8 +2093,12 @@ def run_pipeline(
     # Initialize .sdlc-loop/ directory structure
     init_sdlc_dir()
 
-    # Initialize beliefs system if available
-    beliefs_init()
+    # Initialize reasons database
+    reasons_init()
+
+    # Set reasons DB path for agent prompt injection
+    from .agent import set_reasons_db as set_agent_reasons_db
+    set_agent_reasons_db(get_reasons_db())
 
     # Load shared understanding if provided
     shared_understanding = None
@@ -2492,6 +2426,7 @@ def main():
         print(
             "  --code-review         Run code-review review-loop after PR creation (requires --github-pr)"
         )
+        print("  --reasons-db PATH     Path to reasons database (from code-expert)")
         print("  --beliefs PATH        Beliefs file for code-review (from code-expert)")
         print(
             "  --review-model NAME   Model for code-review (repeatable, default: claude + gemini)"
@@ -2567,6 +2502,7 @@ def main():
     github_pr = False  # Create GitHub PR after run
     code_review = False  # Run code-review after PR creation
     beliefs_path = None  # Beliefs file for code-review
+    reasons_db_path = None  # Reasons database path
     review_models = []  # Models to use for code-review (e.g. claude, gemini)
     repo_path = None  # Code repo path from --repo
     branch_name = None  # Override branch name
@@ -2645,6 +2581,14 @@ def main():
         code_review = True
         args = args[:idx] + args[idx + 1 :]
 
+    if "--reasons-db" in args:
+        idx = args.index("--reasons-db")
+        reasons_db_path = os.path.expanduser(args[idx + 1])
+        if not os.path.isfile(reasons_db_path):
+            print(f"Error: Reasons database not found: {reasons_db_path}")
+            sys.exit(1)
+        args = args[:idx] + args[idx + 2 :]
+
     if "--beliefs" in args:
         idx = args.index("--beliefs")
         beliefs_path = os.path.expanduser(args[idx + 1])
@@ -2677,6 +2621,10 @@ def main():
     # Set the target branch (default: main)
     if branch_name:
         set_target_branch(branch_name)
+
+    # Set external reasons database if provided
+    if reasons_db_path:
+        set_reasons_db(Path(reasons_db_path))
 
     # Add GitLab remote if specified
     repo = get_repo_root()

--- a/src/ftl_sdlc_loop/understand.py
+++ b/src/ftl_sdlc_loop/understand.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from .agent import get_artifacts_dir, get_sdlc_dir
+from .config import get_artifacts_dir, get_sdlc_dir
 
 
 def run_claude(prompt: str, continue_session: bool = False) -> str:

--- a/tests/test_reasons.py
+++ b/tests/test_reasons.py
@@ -1,9 +1,10 @@
-"""Tests for reasons.py CLI wrapper module."""
+"""Tests for reasons.py CLI wrapper and agent.py reasons integration."""
 
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import subprocess
 
+from ftl_sdlc_loop.agent import AGENT_PERMISSIONS, get_reasons_instructions
 from ftl_sdlc_loop.reasons import (
     get_reasons_db,
     set_reasons_db,
@@ -180,3 +181,70 @@ def test_reasons_list_gated_returns_output():
     mock_result = subprocess.CompletedProcess([], 0, "gated: node-1", "")
     with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
         assert reasons_list_gated() == "gated: node-1"
+
+
+# --- agent.py: AGENT_PERMISSIONS ---
+
+
+def test_all_agents_have_bash_access():
+    """Every agent role has some form of Bash access for reasons queries."""
+    for role, perms in AGENT_PERMISSIONS.items():
+        tools = perms["allowed_tools"]
+        has_bash = any(t == "Bash" or t.startswith("Bash(") for t in tools)
+        assert has_bash, f"{role} is missing Bash access"
+
+
+def test_belief_only_agents_have_scoped_bash():
+    """Agents that only need beliefs get Bash(reasons*), not full Bash."""
+    scoped_roles = ["understand", "planner", "implementer", "reviewer"]
+    for role in scoped_roles:
+        tools = AGENT_PERMISSIONS[role]["allowed_tools"]
+        assert "Bash(reasons*)" in tools, f"{role} should have Bash(reasons*)"
+        assert "Bash" not in tools, f"{role} should not have unscoped Bash"
+
+
+def test_shell_agents_have_full_bash():
+    """Tester and user need full Bash for running tests and using software."""
+    for role in ["tester", "user"]:
+        tools = AGENT_PERMISSIONS[role]["allowed_tools"]
+        assert "Bash" in tools, f"{role} should have full Bash"
+
+
+# --- agent.py: get_reasons_instructions() ---
+
+
+def test_get_reasons_instructions_returns_empty_when_db_missing(tmp_path):
+    """Returns empty string when the reasons DB does not exist."""
+    db = tmp_path / "nonexistent.db"
+    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+        assert get_reasons_instructions() == ""
+
+
+def test_get_reasons_instructions_contains_db_path(tmp_path):
+    """Returned prompt includes the database path."""
+    db = tmp_path / "reasons.db"
+    db.write_text("exists")
+    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+        result = get_reasons_instructions()
+        assert str(db) in result
+
+
+def test_get_reasons_instructions_includes_read_commands(tmp_path):
+    """Returned prompt includes the expected read-only commands."""
+    db = tmp_path / "reasons.db"
+    db.write_text("exists")
+    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+        result = get_reasons_instructions()
+        for cmd in ["search", "compact", "list", "list-gated", "explain", "show", "ask"]:
+            assert cmd in result, f"Missing read command: {cmd}"
+
+
+def test_get_reasons_instructions_prohibits_write_commands(tmp_path):
+    """Returned prompt explicitly prohibits write commands."""
+    db = tmp_path / "reasons.db"
+    db.write_text("exists")
+    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+        result = get_reasons_instructions()
+        assert "Do NOT use" in result
+        for cmd in ["add", "retract", "init"]:
+            assert cmd in result, f"Missing prohibition for: {cmd}"

--- a/tests/test_reasons.py
+++ b/tests/test_reasons.py
@@ -129,20 +129,19 @@ def test_reasons_compact_returns_none_on_empty():
         assert reasons_compact() is None
 
 
-def test_reasons_list_warnings_filters():
-    """reasons_list_warnings returns only lines containing 'warn'."""
-    output = "review-warn-1-1 | WARNING | Some issue\nplan-1-1 | AXIOM | Decision\n"
+def test_reasons_list_warnings_passes_label_flag():
+    """reasons_list_warnings uses --label WARNING for precise filtering."""
+    output = "review-warn-1-1 | WARNING | Some issue"
     mock_result = subprocess.CompletedProcess([], 0, output, "")
-    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result) as mock:
         result = reasons_list_warnings()
-        assert result is not None
-        assert "WARNING" in result
-        assert "AXIOM" not in result
+        mock.assert_called_once_with("list", "--status", "IN", "--label", "WARNING")
+        assert result == output
 
 
 def test_reasons_list_warnings_none_when_no_warnings():
     """reasons_list_warnings returns None when no warning lines found."""
-    output = "plan-1-1 | AXIOM | Decision\nimpl-1-1 | DERIVED | Code\n"
+    output = ""
     mock_result = subprocess.CompletedProcess([], 0, output, "")
     with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
         assert reasons_list_warnings() is None

--- a/tests/test_reasons.py
+++ b/tests/test_reasons.py
@@ -215,7 +215,7 @@ def test_shell_agents_have_full_bash():
 def test_get_reasons_instructions_returns_empty_when_db_missing(tmp_path):
     """Returns empty string when the reasons DB does not exist."""
     db = tmp_path / "nonexistent.db"
-    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+    with patch("ftl_sdlc_loop.agent.get_reasons_db", return_value=db):
         assert get_reasons_instructions() == ""
 
 
@@ -223,7 +223,7 @@ def test_get_reasons_instructions_contains_db_path(tmp_path):
     """Returned prompt includes the database path."""
     db = tmp_path / "reasons.db"
     db.write_text("exists")
-    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+    with patch("ftl_sdlc_loop.agent.get_reasons_db", return_value=db):
         result = get_reasons_instructions()
         assert str(db) in result
 
@@ -232,7 +232,7 @@ def test_get_reasons_instructions_includes_read_commands(tmp_path):
     """Returned prompt includes the expected read-only commands."""
     db = tmp_path / "reasons.db"
     db.write_text("exists")
-    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+    with patch("ftl_sdlc_loop.agent.get_reasons_db", return_value=db):
         result = get_reasons_instructions()
         for cmd in ["search", "compact", "list", "list-gated", "explain", "show", "ask"]:
             assert cmd in result, f"Missing read command: {cmd}"
@@ -242,7 +242,7 @@ def test_get_reasons_instructions_prohibits_write_commands(tmp_path):
     """Returned prompt explicitly prohibits write commands."""
     db = tmp_path / "reasons.db"
     db.write_text("exists")
-    with patch("ftl_sdlc_loop.reasons.get_reasons_db", return_value=db):
+    with patch("ftl_sdlc_loop.agent.get_reasons_db", return_value=db):
         result = get_reasons_instructions()
         assert "Do NOT use" in result
         for cmd in ["add", "retract", "init"]:

--- a/tests/test_reasons.py
+++ b/tests/test_reasons.py
@@ -1,0 +1,182 @@
+"""Tests for reasons.py CLI wrapper module."""
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import subprocess
+
+from ftl_sdlc_loop.reasons import (
+    get_reasons_db,
+    set_reasons_db,
+    _run_reasons,
+    reasons_init,
+    reasons_add,
+    reasons_compact,
+    reasons_list_warnings,
+    reasons_search,
+    reasons_list_gated,
+    reasons_retract,
+)
+
+
+def test_get_reasons_db_default():
+    """Default DB path is .sdlc-loop/reasons.db under repo root."""
+    with patch("ftl_sdlc_loop.reasons._reasons_db", None):
+        with patch("ftl_sdlc_loop.reasons.get_sdlc_dir", return_value=Path("/repo/.sdlc-loop")):
+            assert get_reasons_db() == Path("/repo/.sdlc-loop/reasons.db")
+
+
+def test_get_reasons_db_custom():
+    """set_reasons_db overrides the default path."""
+    custom = Path("/tmp/custom.db")
+    set_reasons_db(custom)
+    try:
+        assert get_reasons_db() == custom
+    finally:
+        set_reasons_db(None)
+
+
+def test_run_reasons_constructs_command():
+    """_run_reasons prepends 'reasons --db PATH' to args."""
+    mock_result = subprocess.CompletedProcess([], 0, "output", "")
+    with patch("ftl_sdlc_loop.reasons._reasons_db", Path("/tmp/test.db")):
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            with patch("ftl_sdlc_loop.reasons._find_reasons_bin", return_value="reasons"):
+                _run_reasons("search", "query")
+                cmd = mock_run.call_args[0][0]
+                assert cmd[0] == "reasons"
+                assert cmd[1:3] == ["--db", "/tmp/test.db"]
+                assert cmd[3:] == ["search", "query"]
+
+
+def test_run_reasons_handles_not_found():
+    """_run_reasons returns error result when CLI is not installed."""
+    with patch("ftl_sdlc_loop.reasons._reasons_db", Path("/tmp/test.db")):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with patch("ftl_sdlc_loop.reasons._find_reasons_bin", return_value="reasons"):
+                result = _run_reasons("search", "test")
+                assert result.returncode == 1
+                assert "not found" in result.stderr
+
+
+def test_run_reasons_handles_timeout():
+    """_run_reasons returns error result on timeout."""
+    with patch("ftl_sdlc_loop.reasons._reasons_db", Path("/tmp/test.db")):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["reasons"], 60)):
+            with patch("ftl_sdlc_loop.reasons._find_reasons_bin", return_value="reasons"):
+                result = _run_reasons("compact")
+                assert result.returncode == 1
+                assert "timeout" in result.stderr
+
+
+def test_reasons_init_skips_existing(tmp_path):
+    """reasons_init does nothing if the DB already exists."""
+    db = tmp_path / "reasons.db"
+    db.write_text("existing")
+    with patch("ftl_sdlc_loop.reasons._reasons_db", db):
+        with patch("ftl_sdlc_loop.reasons._run_reasons") as mock:
+            reasons_init()
+            mock.assert_not_called()
+
+
+def test_reasons_init_creates_new(tmp_path):
+    """reasons_init calls 'reasons init' when DB does not exist."""
+    db = tmp_path / "reasons.db"
+    with patch("ftl_sdlc_loop.reasons._reasons_db", db):
+        with patch("ftl_sdlc_loop.reasons._run_reasons") as mock:
+            reasons_init()
+            mock.assert_called_once_with("init")
+
+
+def test_reasons_add_basic():
+    """reasons_add constructs correct CLI args for basic add."""
+    with patch("ftl_sdlc_loop.reasons._run_reasons") as mock:
+        reasons_add("plan-1-1", "Use REST API", label="AXIOM")
+        mock.assert_called_once_with(
+            "add", "plan-1-1", "Use REST API", "--label", "AXIOM"
+        )
+
+
+def test_reasons_add_with_deps_and_source():
+    """reasons_add includes --sl and --source when provided."""
+    with patch("ftl_sdlc_loop.reasons._run_reasons") as mock:
+        reasons_add(
+            "impl-1-foo.py",
+            "Implements handler",
+            label="DERIVED",
+            depends_on=["plan-1-1", "plan-1-2"],
+            source="foo.py",
+        )
+        mock.assert_called_once_with(
+            "add", "impl-1-foo.py", "Implements handler",
+            "--label", "DERIVED",
+            "--sl", "plan-1-1,plan-1-2",
+            "--source", "foo.py",
+        )
+
+
+def test_reasons_compact_returns_output():
+    """reasons_compact returns stdout when present."""
+    mock_result = subprocess.CompletedProcess([], 0, "summary text", "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        assert reasons_compact(500) == "summary text"
+
+
+def test_reasons_compact_returns_none_on_empty():
+    """reasons_compact returns None when stdout is empty."""
+    mock_result = subprocess.CompletedProcess([], 0, "", "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        assert reasons_compact() is None
+
+
+def test_reasons_list_warnings_filters():
+    """reasons_list_warnings returns only lines containing 'warn'."""
+    output = "review-warn-1-1 | WARNING | Some issue\nplan-1-1 | AXIOM | Decision\n"
+    mock_result = subprocess.CompletedProcess([], 0, output, "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        result = reasons_list_warnings()
+        assert result is not None
+        assert "WARNING" in result
+        assert "AXIOM" not in result
+
+
+def test_reasons_list_warnings_none_when_no_warnings():
+    """reasons_list_warnings returns None when no warning lines found."""
+    output = "plan-1-1 | AXIOM | Decision\nimpl-1-1 | DERIVED | Code\n"
+    mock_result = subprocess.CompletedProcess([], 0, output, "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        assert reasons_list_warnings() is None
+
+
+def test_reasons_search_returns_output():
+    """reasons_search returns stdout."""
+    mock_result = subprocess.CompletedProcess([], 0, "found: result", "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        assert reasons_search("test") == "found: result"
+
+
+def test_reasons_search_returns_none_on_empty():
+    """reasons_search returns None when no results."""
+    mock_result = subprocess.CompletedProcess([], 0, "", "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        assert reasons_search("nonexistent") is None
+
+
+def test_reasons_retract_basic():
+    """reasons_retract constructs correct CLI args."""
+    with patch("ftl_sdlc_loop.reasons._run_reasons") as mock:
+        reasons_retract("plan-1-1")
+        mock.assert_called_once_with("retract", "plan-1-1")
+
+
+def test_reasons_retract_with_reason():
+    """reasons_retract includes --reason when provided."""
+    with patch("ftl_sdlc_loop.reasons._run_reasons") as mock:
+        reasons_retract("plan-1-1", reason="No longer valid")
+        mock.assert_called_once_with("retract", "plan-1-1", "--reason", "No longer valid")
+
+
+def test_reasons_list_gated_returns_output():
+    """reasons_list_gated returns stdout."""
+    mock_result = subprocess.CompletedProcess([], 0, "gated: node-1", "")
+    with patch("ftl_sdlc_loop.reasons._run_reasons", return_value=mock_result):
+        assert reasons_list_gated() == "gated: node-1"


### PR DESCRIPTION
## Summary
- **New reasons.py module**: CLI wrapper for the supervisor to register/query beliefs via reasons --db PATH subprocess calls
- **All agents get Bash access**: understand, planner, implementer, reviewer now have Bash alongside tester/user -- needed for reasons CLI queries
- **Agent prompt injection**: Each agent prompt includes read-only reasons CLI commands (search, compact, list, list-gated, explain, show, ask) with explicit prohibition of write commands
- **Supervisor updated**: All beliefs_lib imports and 6 wrapper functions replaced with reasons.py imports; claim registration uses reasons_add() with proper labels (AXIOM, DERIVED, WARNING, OBSERVATION)
- **External DB support**: --reasons-db PATH flag lets the pipeline use a pre-built database (e.g., from code-expert)
- **Dependency updated**: ftl-beliefs to ftl-reasons in pyproject.toml

## Test plan
- [x] All 41 tests pass (18 new in test_reasons.py)
- [ ] Run ftl-sdlc-loop --reasons-db /path/to/db --effort minimal with a pre-built reasons DB
- [ ] Verify agents can query beliefs in their output via reasons search
- [ ] Verify supervisor registers claims (reasons list --status IN)
- [ ] Verify exit gate catches active WARNINGs when user says SATISFIED

Closes #9